### PR TITLE
Initial implementation of microcontroller API

### DIFF
--- a/projects/microcontrollers/build.gradle.kts
+++ b/projects/microcontrollers/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestLogging
+
+buildscript {
+    repositories {
+        gradleScriptKotlin()
+    }
+    dependencies {
+        classpath(kotlinModule("gradle-plugin"))
+    }
+}
+
+apply {
+    plugin("kotlin")
+}
+
+dependencies {
+    compile(kotlinModule("stdlib"))
+    testCompile("junit:junit:4.12")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
+}
+
+tasks.withType<Test> {
+    testLogging(closureOf<TestLogging> {
+        showStandardStreams = true
+        events("passed", "skipped", "failed")
+    })
+}

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/Message.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/Message.kt
@@ -1,0 +1,29 @@
+package microcontrollers
+
+class Message(val command: Byte, val payload: ByteArray) {
+    companion object Constants {
+        const val MESSAGE_START = 0xAA.toByte()
+    }
+
+    val bytes: ByteArray by lazy {
+        val body = arrayOf(MESSAGE_START, command).toByteArray() + payload
+        body + crc16(body)
+    }
+
+    private fun crc16(bytes: ByteArray): ByteArray {
+        var result: Int = 0
+        for (b in bytes.map(Byte::toInt)) {
+            for (i in 0..7) {
+                val bit = (b shr (7 - i) and 1) == 1
+                val c15 = (result shr 15 and 1) == 1
+                result = result shl 1
+                if (c15 xor bit) {
+                    result = result xor 4129
+                }
+            }
+        }
+
+        result = result and 0xFFFF
+        return arrayOf((result shr 8).toByte(), result.toByte()).toByteArray()
+    }
+}

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/MessageState.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/MessageState.kt
@@ -1,0 +1,40 @@
+package microcontrollers
+
+internal sealed class MessageState {
+    class Started : MessageState() {
+        fun next(recv: () -> Byte, buffer: (Byte) -> Unit): MessageState {
+            val byte = recv()
+
+            if (byte == Message.MESSAGE_START) {
+                buffer(byte)
+                return MessageState.Command()
+            } else {
+                // This isn't the byte we're looking for
+                return MessageState.Started()
+            }
+        }
+    }
+    class Command : MessageState() {
+        fun next(recv: () -> Byte, buffer: (Byte) -> Unit, payloadSizes: Map<Byte, Int>): MessageState {
+            val command = recv()
+            buffer(command)
+
+            if (!payloadSizes.containsKey(command)) {
+                // Invalid command received
+                return MessageState.Started()
+            } else {
+                val payloadSize = payloadSizes[command]!!
+                return MessageState.Payload(payloadSize)
+            }
+        }
+    }
+    class Payload(val payloadSize: Int) : MessageState() {
+        fun next(recv: () -> Byte, buffer: (Byte) -> Unit): MessageState {
+            for (i in 0..(payloadSize - 1)) {
+                buffer(recv())
+            }
+            return MessageState.Checksum()
+        }
+    }
+    class Checksum : MessageState()
+}

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/Microcontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/Microcontroller.kt
@@ -1,0 +1,52 @@
+package microcontrollers
+
+import java.nio.ByteBuffer
+import java.util.concurrent.locks.Lock
+
+internal interface Microcontroller {
+    val payloadSizes: Map<Byte, Int>
+
+    val lock: Lock
+
+    val recv: () -> Byte
+    val send: (ByteArray) -> Unit
+
+    fun writeMessage(m: Message): Message {
+        return sync {
+            send(m.bytes)
+            return@sync readMessage()
+        }
+    }
+
+    private fun readMessage(): Message {
+        var state: MessageState = MessageState.Started()
+        var buffer = ByteBuffer.allocate(128)
+        while (true) {
+            state = when (state) {
+                is MessageState.Started -> state.next(recv, { b -> buffer.put(b) })
+                is MessageState.Command -> state.next(recv, { b -> buffer.put(b) }, payloadSizes)
+                is MessageState.Payload -> state.next(recv, { b -> buffer.put(b) })
+                is MessageState.Checksum -> {
+                    val bytes = buffer.array().sliceArray(0 until buffer.position())
+
+                    recv()
+                    recv()
+                    // We might want to validate this checksum at some point?
+                    buffer.clear()
+
+                    return Message(bytes[1], bytes.sliceArray(2..bytes.lastIndex))
+                }
+            }
+        }
+    }
+
+    private fun <T> sync(f: () -> T): T {
+        lock.lock()
+        try {
+            return f()
+        }
+        finally {
+            lock.unlock()
+        }
+    }
+}

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/PropulsionMicrocontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/PropulsionMicrocontroller.kt
@@ -1,0 +1,21 @@
+package microcontrollers
+
+import java.nio.ByteBuffer
+import java.util.concurrent.locks.Lock
+
+class PropulsionMicrocontroller(override val lock: Lock, override val recv: () -> Byte, override val send: (ByteArray) -> Unit) : Microcontroller {
+    override val payloadSizes: Map<Byte, Int> = mapOf(
+        0x10.toByte() to 1,
+        0x13.toByte() to 4,
+        0x1F.toByte() to 1
+    )
+
+    fun reset(): Message {
+        return writeMessage(Message(0x10, byteArrayOf(0x00)))
+    }
+
+    fun setSpeed(m0: Short, m1: Short): Message {
+        val buffer = ByteBuffer.allocate(4).putShort(m0).putShort(m1).array()
+        return writeMessage(Message(0x13, buffer))
+    }
+}

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkMicrocontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkMicrocontroller.kt
@@ -1,0 +1,27 @@
+package microcontrollers
+
+import java.util.concurrent.locks.Lock
+
+class WirelessLinkMicrocontroller(override val lock: Lock, override val recv: () -> Byte, override val send: (ByteArray) -> Unit) : Microcontroller {
+    override val payloadSizes: Map<Byte, Int> = mapOf(
+        0x00.toByte() to 1,
+        0x03.toByte() to 64,
+        0x04.toByte() to 1,
+        0x0F.toByte() to 1
+    )
+
+    fun reset(): Message {
+        return writeMessage(Message(0x00, byteArrayOf(0x00)))
+    }
+
+    fun receive(): Message {
+        return writeMessage(Message(0x03, byteArrayOf(0x00)))
+    }
+
+    fun send(bytes: ByteArray): Message {
+        if (bytes.size > 61) {
+            throw IllegalArgumentException("Message payload must be !> 61 bytes, ${bytes.size} given")
+        }
+        return writeMessage(Message(0x04, bytes))
+    }
+}

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/MessageTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/MessageTest.kt
@@ -1,0 +1,17 @@
+@file:Suppress("DEPRECATION")
+
+package microcontrollers
+
+import org.junit.Test
+import kotlin.test.CollectionAssertionSession
+import kotlin.test.shouldBe
+
+class MessageTest {
+    @Test
+    fun messageBytesAreCorrect() {
+        val message = Message(0x10, byteArrayOf(0x00))
+        val expected = byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E)
+
+        CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expected.asIterable())
+    }
+}

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/PropulsionMicrocontrollerTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/PropulsionMicrocontrollerTest.kt
@@ -1,0 +1,40 @@
+@file:Suppress("DEPRECATION")
+
+package microcontrollers
+
+import org.junit.Test
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.test.CollectionAssertionSession
+import kotlin.test.shouldBe
+
+class PropulsionMicrocontrollerTest {
+    @Test(timeout = 10000)
+    fun reset() {
+        val expectedSend = byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E)
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E)
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val sent = mutableListOf<Byte>()
+        val microcontroller = PropulsionMicrocontroller(
+            ReentrantLock(), recv, { bytes -> bytes.forEach { sent.add(it) } })
+
+        microcontroller.reset()
+        CollectionAssertionSession(sent).shouldBe(expectedSend.asIterable())
+    }
+
+    @Test(timeout = 10000)
+    fun setSpeed() {
+        val expectedSend = byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte())
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte())
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val sent = mutableListOf<Byte>()
+        val microcontroller = PropulsionMicrocontroller(
+            ReentrantLock(), recv, { bytes -> bytes.forEach { sent.add(it) } })
+
+        microcontroller.setSpeed(128, 0)
+        CollectionAssertionSession(sent).shouldBe(expectedSend.asIterable())
+    }
+}

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/WirelessLinkMicrocontrollerTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/WirelessLinkMicrocontrollerTest.kt
@@ -1,0 +1,58 @@
+@file:Suppress("DEPRECATION")
+
+package microcontrollers
+
+import org.junit.Test
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.test.CollectionAssertionSession
+import kotlin.test.shouldBe
+
+class WirelessLinkMicrocontrollerTest {
+    @Test(timeout = 10000)
+    fun reset() {
+        val expectedSend = byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D)
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D)
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val sent = mutableListOf<Byte>()
+        val microcontroller = WirelessLinkMicrocontroller(
+            ReentrantLock(), recv, { bytes -> bytes.forEach { sent.add(it) } })
+
+        val message = microcontroller.reset()
+        CollectionAssertionSession(sent).shouldBe(expectedSend.asIterable())
+        CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expectedRecv.asIterable())
+    }
+
+    @Test(timeout = 10000)
+    fun receive() {
+        val expectedSend = byteArrayOf(0xAA.toByte(), 0x03, 0x00, 0x2F, 0x0E)
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x33 }) + byteArrayOf(0x06, 0x9F.toByte())
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val sent = mutableListOf<Byte>()
+        val microcontroller = WirelessLinkMicrocontroller(
+            ReentrantLock(), recv, { bytes -> bytes.forEach { sent.add(it) } })
+
+        val message = microcontroller.receive()
+        CollectionAssertionSession(sent).shouldBe(expectedSend.asIterable())
+        CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expectedRecv.asIterable())
+    }
+
+    @Test(timeout = 10000)
+    fun send() {
+        val expectedSend = byteArrayOf(0xAA.toByte(), 0x04) + ByteArray(61, { 0x42 }) + byteArrayOf(0xE2.toByte(), 0x7F)
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x04, 0x01, 0xA6.toByte(), 0xB8.toByte())
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val sent = mutableListOf<Byte>()
+        val microcontroller = WirelessLinkMicrocontroller(
+            ReentrantLock(), recv, { bytes -> bytes.forEach { sent.add(it) } })
+
+        val message = microcontroller.send(ByteArray(61, { 0x42 }))
+        CollectionAssertionSession(sent).shouldBe(expectedSend.asIterable())
+        CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expectedRecv.asIterable())
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include "core"
 include "cli"
+include "microcontrollers"
 
 rootProject.name = "boat"
 rootProject.buildFileName = "build.gradle.kts"


### PR DESCRIPTION
This PR adds the initial implementation of the microcontroller communications for the boat (sans-I/O) and the commands from the Propulsion and Wireless Microcontroller APIs needed for Rev 1 and Rev 1.1.

Implemented commands:

- [`0x00`](https://github.com/LakeMaps/microcontrollers/wiki/Wireless-Communication-Microcontroller-API#command-0x00--reset-wireless-module)
- [`0x03`](https://github.com/LakeMaps/microcontrollers/wiki/Wireless-Communication-Microcontroller-API#command-0x03--wireless-receive)
- [`0x04`](https://github.com/LakeMaps/microcontrollers/wiki/Wireless-Communication-Microcontroller-API#command-0x04--wireless-transmit)
- [`0x10`](https://github.com/LakeMaps/microcontrollers/wiki/Propulsion-Microcontroller-API#command-0x10--reset-motor-controller)
- [`0x13`](https://github.com/LakeMaps/microcontrollers/wiki/Propulsion-Microcontroller-API#command-0x13--set-motor-speeds)