### PR TITLE
Extract Travis CI config into scripts

### DIFF
--- a/.ci/travis/compile
+++ b/.ci/travis/compile
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+gradle build

--- a/.ci/travis/install
+++ b/.ci/travis/install
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+(
+       cd "${HOME}" \
+    && curl -sSLO "${GRADLE_DISTRIBUTION_URL}" \
+    && unzip -q $(basename "${GRADLE_DISTRIBUTION_URL}") \
+    && mv "gradle-${GRADLE_VERSION}" "gradle"
+)

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ matrix:
         - jdk: oraclejdk7
           os: linux
 before_install:
-    - (cd "$HOME" && curl -sSLO "$GRADLE_DISTRIBUTION_URL")
-    - (cd "$HOME" && unzip -q $(basename "$GRADLE_DISTRIBUTION_URL"))
-    - export PATH="$HOME/gradle-$GRADLE_VERSION/bin:$PATH"
-    - gradle --version
+    - .ci/travis/install
+    - export PATH="${HOME}/gradle/bin:${PATH}"
 script:
-    - gradle build
+    - .ci/travis/compile
 
 notifications:
     email: false


### PR DESCRIPTION
This PR moves all of the fun Travis CI build logic into scripts under a `.ci/travis/` directory.