### PR TITLE
Update Travis CI to build on their Trusty images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: java
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ env:
         - GRADLE_VERSION='3.4-20161216120313+0000'
         - GRADLE_DISTRIBUTION_URL="https://repo.gradle.org/gradle/dist-snapshots/gradle-script-kotlin-$GRADLE_VERSION-bin.zip"
         - TERM=dumb
-matrix:
-    include:
-        - jdk: oraclejdk8
-          os: linux
+jdk:
+    - oraclejdk8
+    - openjdk8
 before_install:
     - (
            cd "${HOME}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_install:
     - export PATH="${HOME}/gradle/bin:${PATH}"
     - hash -r
     - gradle --version
+install:
+    - gradle resolveAllDependencies
 script:
     - gradle build
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,12 @@ allprojects {
     }
 }
 
+allprojects {
+    task("resolveAllDependencies", {
+        doLast { configurations.all { it.resolve() } }
+    })
+}
+
 plugins {
     base
 }


### PR DESCRIPTION
This PR updates the Travis CI config to use their [Trusty beta build environment](https://docs.travis-ci.com/user/trusty-ci-environment/). The Trusty images have OpenJDK 8, allowing us to test the control software runs on both Oracle's JDK and the OpenJDK builds.

Tasks:

- [x] Update to Trusty Tahr
- [x] Build on both Oracle and OpenJDK 8