### PR TITLE
Skip corrupt messages when receiving from microcontrollers

### DIFF
--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/Message.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/Message.kt
@@ -10,6 +10,10 @@ class Message(val command: Byte, val payload: ByteArray) {
         body + crc16(body)
     }
 
+    val checksum: ByteArray by lazy {
+        bytes.sliceArray((bytes.lastIndex - 1)..bytes.lastIndex)
+    }
+
     private fun crc16(bytes: ByteArray): ByteArray {
         var result: Int = 0
         for (b in bytes.map(Byte::toInt)) {

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/MessageTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/MessageTest.kt
@@ -14,4 +14,12 @@ class MessageTest {
 
         CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expected.asIterable())
     }
+
+    @Test
+    fun messageChecksumBytesAreCorrect() {
+        val message = Message(0x10, byteArrayOf(0x00))
+        val expected = byteArrayOf(0x79, 0x2E)
+
+        CollectionAssertionSession(message.checksum.asIterable()).shouldBe(expected.asIterable())
+    }
 }

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/MicrocontrollerTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/MicrocontrollerTest.kt
@@ -1,0 +1,36 @@
+@file:Suppress("DEPRECATION")
+
+package microcontrollers
+
+import org.junit.Test
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.test.CollectionAssertionSession
+import kotlin.test.shouldBe
+
+private class SimpleMicrocontroller(
+    override val lock: Lock,
+    override val recv: () -> Byte,
+    override val send: (ByteArray) -> Unit
+) : Microcontroller
+{
+    override val payloadSizes: Map<Byte, Int>
+        get() = mapOf(0x10.toByte() to 0x01)
+}
+
+class MicrocontrollerTest {
+    @Test
+    fun readMessageDoesSkipCorruptMessages() {
+        val receiveBuffer = byteArrayOf(0xAA.toByte(), 0x10, 0x42, 0x79, 0x2E, 0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E)
+        val expectedMsg = byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E)
+
+        var recvCallCount = 0
+        val recv = { receiveBuffer[recvCallCount++] }
+        val sent = mutableListOf<Byte>()
+        val microcontroller = SimpleMicrocontroller(
+            ReentrantLock(), recv, { bytes -> bytes.forEach { sent.add(it) } })
+
+        val message = microcontroller.writeMessage(Message(0x10, byteArrayOf(0x00)))
+        CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expectedMsg.asIterable())
+    }
+}


### PR DESCRIPTION
This PR updates the microcontroller message parsing to skip corrupt messages.