### PR TITLE
Implement GPS parser

### DIFF
--- a/projects/gps/build.gradle.kts
+++ b/projects/gps/build.gradle.kts
@@ -1,0 +1,28 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestLogging
+
+buildscript {
+    repositories {
+        gradleScriptKotlin()
+    }
+    dependencies {
+        classpath(kotlinModule("gradle-plugin"))
+    }
+}
+
+apply {
+    plugin("kotlin")
+}
+
+dependencies {
+    compile(kotlinModule("stdlib"))
+    testCompile("junit:junit:4.12")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
+}
+
+tasks.withType<Test> {
+    testLogging(closureOf<TestLogging> {
+        showStandardStreams = true
+        events("passed", "skipped", "failed")
+    })
+}

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -9,6 +9,22 @@ import java.time.OffsetTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
+/**
+ * A GPS device.
+ *
+ * The use of the input and output functions are controlled by [poll]ing the device. Each call
+ * to [poll] reads a number of characters from the input function and parses them into a NMEA 0183
+ * sentence, which is passed to [callback]. For example:
+ *
+ *     val serial = Serial("/dev/ttyS0")
+ *     val gps = Gps({ serial.read() }, { msg -> })
+ *     gps.poll()
+ *
+ * **Note: this implementation supports `GGA`, `GSA`, `GSV`, `RMC`, and `VTG` sentences only.**
+ *
+ * @param recv an input function returning a character from the GPS
+ * @param callback an output function accepting a GPS sentence
+ */
 class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
     private val parser = SentenceParser(recv)
 

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -1,0 +1,93 @@
+package gps
+
+import gps.parser.Sentence
+import gps.parser.SentenceParser
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
+    private val parser = SentenceParser(recv)
+
+    fun poll() {
+        val sentence = parser.nextMessage()
+        val type = String(sentence.type)
+        when (type) {
+            "GGA" -> callback(gga(sentence))
+            "GSA" -> callback(gsa(sentence))
+            "GSV" -> callback(gsv(sentence))
+            "RMC" -> callback(rmc(sentence))
+            "VTG" -> callback(vtg(sentence))
+        }
+    }
+
+    internal fun gga(sentence: Sentence): GpsFix {
+        val time = OffsetTime.of(sentence.time(0), ZoneOffset.UTC)
+        val position = GpsPosition(latitude = sentence.double(1), longitude = sentence.double(3))
+        val dOP = GpsDilutionOfPrecision(horizontal = sentence.double(7))
+        return GpsFix(time, position, sentence.char(5), sentence.int(6), dOP, sentence.double(8), sentence.double(10))
+    }
+
+    internal fun gsa(sentence: Sentence): GpsActiveSatellites {
+        val channels = GpsChannelArray((2..15).mapNotNull { sentence.intOrNull(it) }.toIntArray())
+        val dilutionOfPrecision = GpsDilutionOfPrecision(sentence.double(14), sentence.double(15), sentence.double(16))
+        return GpsActiveSatellites(sentence.char(0), sentence.char(1), channels, dilutionOfPrecision)
+    }
+
+    internal fun gsv(sentence: Sentence): GpsSatellitesInView {
+        // These are all conditional for the sake of "symmetry", the first channel should always have an ID
+        val channel1Id = sentence.intOrNull( 3)
+        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, sentence.intOrNull( 4), sentence.intOrNull( 5), sentence.int( 6)) }
+
+        val channel2Id = sentence.intOrNull( 7)
+        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, sentence.intOrNull( 8), sentence.intOrNull( 9), sentence.int(10)) }
+
+        val channel3Id = sentence.intOrNull(11)
+        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, sentence.intOrNull(12), sentence.intOrNull(13), sentence.int(14)) }
+
+        val channel4Id = sentence.intOrNull(15)
+        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, sentence.intOrNull(16), sentence.intOrNull(17), sentence.int(18)) }
+
+        return GpsSatellitesInView(sentence.int(0), sentence.int(1), sentence.int(2), channel1!!, channel2, channel3, channel4)
+    }
+
+    internal fun rmc(sentence: Sentence): GpsNavInfo {
+        val date = sentence.date(8)
+        val time = sentence.time(0)
+        val datetime = OffsetDateTime.of(date, time, ZoneOffset.UTC)
+        val status = sentence.char(1) == GpsNavInfo.STATUS_VALID
+        val position = GpsPosition(sentence.double(4), sentence.double(2))
+        return GpsNavInfo(datetime, status, position, sentence.double(6), sentence.double(7), sentence.char(11))
+    }
+
+    internal fun vtg(sentence: Sentence): GpsGroundVelocity {
+        return GpsGroundVelocity(sentence.double(0), sentence.double(4), sentence.char(8))
+    }
+
+    private fun Sentence.time(index: Int): LocalTime {
+        return LocalTime.parse(String(this.fields[index]), DateTimeFormatter.ofPattern("HHmmss.SSS"))
+    }
+
+    private fun Sentence.date(index: Int): LocalDate {
+        return LocalDate.parse(String(this.fields[index]), DateTimeFormatter.ofPattern("ddMMyy"))
+    }
+
+    private fun Sentence.char(index: Int): Char {
+        return this.fields[index][0]
+    }
+
+    private fun Sentence.intOrNull(index: Int): Int? {
+        return this.fields.getOrNull(index)?.let { String(it).toIntOrNull(radix = 10) }
+    }
+
+    private fun Sentence.int(index: Int): Int {
+        return String(this.fields[index]).toInt(radix = 10)
+    }
+
+    private fun Sentence.double(index: Int): Double {
+        return String(this.fields[index]).toDouble()
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/GpsActiveSatellites.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsActiveSatellites.kt
@@ -1,0 +1,16 @@
+package gps
+
+data class GpsActiveSatellites(
+    val mode1: Char,
+    val mode2: Char,
+    val satellitesUsed: GpsChannelArray,
+    val dilutionOfPrecision: GpsDilutionOfPrecision
+) {
+    companion object {
+        const val AUTOMATIC_MODE = 'A'
+        const val FIX_NOT_AVAILABLE = '1'
+        const val MANUAL_MODE = 'M'
+        const val MODE_2D = '2'
+        const val MODE_3D = '3'
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/GpsActiveSatellites.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsActiveSatellites.kt
@@ -3,8 +3,8 @@ package gps
 data class GpsActiveSatellites(
     val mode1: Char,
     val mode2: Char,
-    val satellitesUsed: GpsChannelArray,
-    val dilutionOfPrecision: GpsDilutionOfPrecision
+    val satellitesUsed: GpsChannelArray?,
+    val dilutionOfPrecision: GpsDilutionOfPrecision?
 ) {
     companion object {
         const val AUTOMATIC_MODE = 'A'

--- a/projects/gps/src/main/kotlin/gps/GpsActiveSatellites.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsActiveSatellites.kt
@@ -1,5 +1,14 @@
 package gps
 
+/**
+ * A NMEA 0183 `GSA` sentence containing GNSS DOP and active satellites.
+ *
+ * @property mode1 whether the device is in [MANUAL_MODE] or [AUTOMATIC_MODE]
+ * @property mode2 whether the device has a fix or is [MODE_2D] or [MODE_3D]
+ * @property satellitesUsed an array of the satellite IDs on channels 1 through 12
+ * @property dilutionOfPrecision the dilution of precision
+ * @constructor Constructs a GSA sentence with the given properties
+ */
 data class GpsActiveSatellites(
     val mode1: Char,
     val mode2: Char,

--- a/projects/gps/src/main/kotlin/gps/GpsChannelArray.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsChannelArray.kt
@@ -2,6 +2,11 @@ package gps
 
 import java.util.Arrays
 
+/**
+ * An array of numbers, one per channel.
+ *
+ * @property channels the array of channel values
+ */
 class GpsChannelArray(val channels: IntArray) {
     override fun equals(other: Any?): Boolean {
         if (this === other) {

--- a/projects/gps/src/main/kotlin/gps/GpsChannelArray.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsChannelArray.kt
@@ -1,0 +1,20 @@
+package gps
+
+import java.util.Arrays
+
+class GpsChannelArray(val channels: IntArray) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (other?.let { it::class.java } != this::class.java) {
+            return false
+        }
+
+        return Arrays.equals(channels, (other as GpsChannelArray).channels)
+    }
+
+    override fun hashCode(): Int {
+        return Arrays.hashCode(channels)
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/GpsDilutionOfPrecision.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsDilutionOfPrecision.kt
@@ -1,0 +1,3 @@
+package gps
+
+data class GpsDilutionOfPrecision(val position: Double? = null, val horizontal: Double? = null, val vertical: Double? = null)

--- a/projects/gps/src/main/kotlin/gps/GpsDilutionOfPrecision.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsDilutionOfPrecision.kt
@@ -1,3 +1,10 @@
 package gps
 
+/**
+ * A set of dilution of precision (DOP) values.
+ *
+ * @property position Position dilution of precision
+ * @property horizontal Horizontal dilution of precision
+ * @property vertical Vertical dilution of precision
+ */
 data class GpsDilutionOfPrecision(val position: Double? = null, val horizontal: Double? = null, val vertical: Double? = null)

--- a/projects/gps/src/main/kotlin/gps/GpsFix.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsFix.kt
@@ -4,12 +4,12 @@ import java.time.OffsetTime
 
 data class GpsFix(
     val time: OffsetTime,
-    val position: GpsPosition,
+    val position: GpsPosition?,
     val positionFixIndicator: Char,
     val satellitesUsed: Int,
-    val dilutionOfPrecision: GpsDilutionOfPrecision,
-    val altitude: Double,
-    val geoidalSeparation: Double
+    val dilutionOfPrecision: GpsDilutionOfPrecision?,
+    val altitude: Double?,
+    val geoidalSeparation: Double?
 ) {
     companion object {
         const val FIX_NOT_AVAILABLE = '0'

--- a/projects/gps/src/main/kotlin/gps/GpsFix.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsFix.kt
@@ -2,6 +2,17 @@ package gps
 
 import java.time.OffsetTime
 
+/**
+ * An NMEA 0183 GGA sentence.
+ *
+ * @property time UTC time of this position
+ * @property position the GPS position
+ * @property positionFixIndicator whether the device does ([GPS_FIX] or [DIFFERENTIAL_GPS_FIX]) or does not have a fix ([FIX_NOT_AVAILABLE])
+ * @property satellitesUsed the number of satellites used in this position (from 0 to 14)
+ * @property dilutionOfPrecision the dilution of precision
+ * @property altitude antenna altitude above or below mean-sea-level in meters
+ * @property geoidalSeparation geoidal separation
+ */
 data class GpsFix(
     val time: OffsetTime,
     val position: GpsPosition?,

--- a/projects/gps/src/main/kotlin/gps/GpsFix.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsFix.kt
@@ -1,0 +1,19 @@
+package gps
+
+import java.time.OffsetTime
+
+data class GpsFix(
+    val time: OffsetTime,
+    val position: GpsPosition,
+    val positionFixIndicator: Char,
+    val satellitesUsed: Int,
+    val dilutionOfPrecision: GpsDilutionOfPrecision,
+    val altitude: Double,
+    val geoidalSeparation: Double
+) {
+    companion object {
+        const val FIX_NOT_AVAILABLE = '0'
+        const val GPS_FIX = '1'
+        const val DIFFERENTIAL_GPS_FIX = '2'
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
@@ -1,5 +1,12 @@
 package gps
 
+/**
+ * An NMEA 0183 `VTG` sentence.
+ *
+ * @property course the measured heading
+ * @property speed the measured speed in knots
+ * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
+ */
 data class GpsGroundVelocity(val course: Double, val speed: Double, val mode: Char) {
     companion object {
         const val MODE_AUTONOMOUS = 'A'

--- a/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
@@ -1,0 +1,9 @@
+package gps
+
+data class GpsGroundVelocity(val course: Double, val speed: Double, val mode: Char) {
+    companion object {
+        const val MODE_AUTONOMOUS = 'A'
+        const val MODE_DIFFERENTIAL = 'D'
+        const val MODE_ESTIMATED = 'E'
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -5,9 +5,9 @@ import java.time.OffsetDateTime
 data class GpsNavInfo(
     val instant: OffsetDateTime,
     val valid: Boolean,
-    val position: GpsPosition,
-    val speed: Double,
-    val course: Double,
+    val position: GpsPosition?,
+    val speed: Double?,
+    val course: Double?,
     val mode: Char
 ) {
     companion object {

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -1,0 +1,19 @@
+package gps
+
+import java.time.OffsetDateTime
+
+data class GpsNavInfo(
+    val instant: OffsetDateTime,
+    val valid: Boolean,
+    val position: GpsPosition,
+    val speed: Double,
+    val course: Double,
+    val mode: Char
+) {
+    companion object {
+        const val STATUS_VALID = 'A'
+        const val MODE_AUTONOMOUS = 'A'
+        const val MODE_DIFFERENTIAL = 'D'
+        const val MODE_ESTIMATED = 'E'
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -2,6 +2,16 @@ package gps
 
 import java.time.OffsetDateTime
 
+/**
+ * An NMEA 0183 `RMC` sentence.
+ *
+ * @property instant the timestamp for this measurement
+ * @property valid whether or not this position is valid
+ * @property position the GPS position
+ * @property speed the measured speed in knots
+ * @property course the measured heading
+ * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
+ */
 data class GpsNavInfo(
     val instant: OffsetDateTime,
     val valid: Boolean,

--- a/projects/gps/src/main/kotlin/gps/GpsPosition.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsPosition.kt
@@ -1,0 +1,3 @@
+package gps
+
+data class GpsPosition(val longitude: Double, val latitude: Double)

--- a/projects/gps/src/main/kotlin/gps/GpsPosition.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsPosition.kt
@@ -1,3 +1,9 @@
 package gps
 
+/**
+ * A GPS position value.
+ *
+ * @property longitude the longitude in degrees decimal minute
+ * @property latitude the latitude in degrees decimal minute
+ */
 data class GpsPosition(val longitude: Double, val latitude: Double)

--- a/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
@@ -1,0 +1,3 @@
+package gps
+
+data class GpsSatelliteMessage(val id: Int, val elevation: Int?, val azimuth: Int?, val signalRatio: Int?)

--- a/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
@@ -1,3 +1,11 @@
 package gps
 
+/**
+ * A satellite message.
+ *
+ * @property id the satellite ID (from 1 to 32)
+ * @property elevation the elevation in degrees
+ * @property azimuth the azimuth measurement in degrees
+ * @property signalRatio the signal-to-noise ratio in dBHz
+ */
 data class GpsSatelliteMessage(val id: Int, val elevation: Int?, val azimuth: Int?, val signalRatio: Int?)

--- a/projects/gps/src/main/kotlin/gps/GpsSatellitesInView.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatellitesInView.kt
@@ -1,0 +1,11 @@
+package gps
+
+data class GpsSatellitesInView(
+    val messageCount: Int,
+    val messageIndex: Int,
+    val satellitesInView: Int,
+    val channel1: GpsSatelliteMessage,
+    val channel2: GpsSatelliteMessage? = null,
+    val channel3: GpsSatelliteMessage? = null,
+    val channel4: GpsSatelliteMessage? = null
+)

--- a/projects/gps/src/main/kotlin/gps/GpsSatellitesInView.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatellitesInView.kt
@@ -4,7 +4,7 @@ data class GpsSatellitesInView(
     val messageCount: Int,
     val messageIndex: Int,
     val satellitesInView: Int,
-    val channel1: GpsSatelliteMessage,
+    val channel1: GpsSatelliteMessage? = null,
     val channel2: GpsSatelliteMessage? = null,
     val channel3: GpsSatelliteMessage? = null,
     val channel4: GpsSatelliteMessage? = null

--- a/projects/gps/src/main/kotlin/gps/GpsSatellitesInView.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatellitesInView.kt
@@ -1,5 +1,21 @@
 package gps
 
+/**
+ * An NMEA 0183 `GSV` sentence.
+ *
+ * Depending on the number of satellites tracked, multiple `GSV` messages may
+ * be required to represent each satellite. The message count and index will
+ * note how many more messages exist in addition to this message in order to
+ * get a complete list of all of the satellites.
+ *
+ * @property messageCount the total message count for a round
+ * @property messageIndex the message index (out of the message count)
+ * @property satellitesInView the number of satellites in view
+ * @property channel1 the satellite message on channel 1
+ * @property channel2 the satellite message on channel 2
+ * @property channel3 the satellite message on channel 3
+ * @property channel4 the satellite message on channel 4
+ */
 data class GpsSatellitesInView(
     val messageCount: Int,
     val messageIndex: Int,

--- a/projects/gps/src/main/kotlin/gps/parser/Sentence.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/Sentence.kt
@@ -1,0 +1,43 @@
+package gps.parser
+
+import java.util.Locale
+
+/**
+ * A NMEA 0183 sentence.
+ *
+ * This representation does not support messages that have special encapsulation as it assumes
+ * that the prefix of the message is '$' and that there is a set of fields.
+ *
+ * @param talker the identifier of the "talker"
+ * @param type the message type
+ * @param fields an array of fields in the message
+ * @property checksum the checksum of this sentence
+ * @constructor Constructs a sentence with the given talker, type, and fields
+ */
+class Sentence(val talker: CharArray, val type: CharArray, val fields: Array<CharArray>) {
+    companion object {
+        const val MESSAGE_START = 0x24.toChar()
+        const val FIELD_DELIMITER = 0x2C.toChar()
+        const val CHECKSUM_DELIMITER = 0x2A.toChar()
+    }
+
+    constructor(talker: String, type: String, fields: Array<String>)
+        : this(talker.toCharArray(), type.toCharArray(), fields.map(String::toCharArray).toTypedArray())
+
+    private val data: CharArray by lazy {
+        fields.fold(charArrayOf(), { acc, chars -> acc + FIELD_DELIMITER + chars })
+    }
+
+    val checksum: Char by lazy {
+        checksum(talker + type + data)
+    }
+
+    private fun checksum(chars: CharArray): Char {
+        return chars.fold(0, { acc, c -> acc.xor(c.toInt()) }).toChar()
+    }
+
+    override fun toString(): String {
+        val cs = String.format(Locale.ENGLISH, "%s%02X", CHECKSUM_DELIMITER, checksum.toByte())
+        return (talker + type + data).joinToString(prefix = MESSAGE_START.toString(), separator = "", postfix = cs)
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/parser/Sentence.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/Sentence.kt
@@ -17,6 +17,8 @@ import java.util.Locale
 class Sentence(val talker: CharArray, val type: CharArray, val fields: Array<CharArray>) {
     companion object {
         const val MESSAGE_START = 0x24.toChar()
+        const val MESSAGE_END1 = 0x0D.toChar()
+        const val MESSAGE_END2 = 0x0A.toChar()
         const val FIELD_DELIMITER = 0x2C.toChar()
         const val CHECKSUM_DELIMITER = 0x2A.toChar()
     }

--- a/projects/gps/src/main/kotlin/gps/parser/SentenceParser.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/SentenceParser.kt
@@ -1,0 +1,19 @@
+package gps.parser
+
+class SentenceParser(private val recv: () -> Char) {
+    fun nextMessage(): Sentence {
+        var state: SentenceState = SentenceState.Prefix()
+        while (true) {
+            state = when (state) {
+                is SentenceState.Prefix      -> state.next(recv)
+                is SentenceState.Talker      -> state.next(recv)
+                is SentenceState.MessageType -> state.next(recv)
+                is SentenceState.Fields      -> state.next(recv)
+                is SentenceState.Checksum    -> state.next(recv)
+                is SentenceState.Complete    -> {
+                    return Sentence(state.talker, state.type, state.fields)
+                }
+            }
+        }
+    }
+}

--- a/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
@@ -56,6 +56,10 @@ internal sealed class SentenceState {
                     fields.add(field.toCharArray())
                     return SentenceState.Checksum(talker, type, fields.toTypedArray())
                 }
+                if (char == Sentence.MESSAGE_END1 || char == Sentence.MESSAGE_END2) {
+                    fields.add(field.toCharArray())
+                    return SentenceState.Complete(talker, type, fields.toTypedArray())
+                }
                 // We've seen 7 chars from previous states
                 if ((count + 7) > MAXIMUM_SENTENCE_LENGTH) {
                     return SentenceState.Prefix()

--- a/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
@@ -1,0 +1,79 @@
+package gps.parser
+
+internal sealed class SentenceState {
+    companion object {
+        const val MAXIMUM_SENTENCE_LENGTH = 82
+    }
+
+    internal class Prefix : SentenceState() {
+        fun next(recv: () -> Char): SentenceState {
+            val char = recv()
+            if (char == Sentence.MESSAGE_START) {
+                return SentenceState.Talker()
+            } else {
+                return SentenceState.Prefix()
+            }
+        }
+    }
+
+    internal class Talker: SentenceState() {
+        fun next(recv: () -> Char): SentenceState {
+            val talker = charArrayOf(recv(), recv())
+            return SentenceState.MessageType(talker)
+        }
+    }
+
+    internal class MessageType(val talker: CharArray): SentenceState() {
+        fun next(recv: () -> Char): SentenceState {
+            // Instead of validating this message's type and trying to pair it with the
+            // number of fields we should expect, we'll not do any of that and take as
+            // many fields as we can in the next state and leave validation for a later time.
+            // Essentially, we're operating under the assumption that most messages are
+            // valid with the correct fields and whatnot. If that turns out to not be the
+            // case, we might regret this decision.
+            val type = charArrayOf(recv(), recv(), recv())
+            // This next char should be field delimiter and we'll throw it away
+            recv()
+            return SentenceState.Fields(talker, type)
+        }
+    }
+
+    internal class Fields(val talker: CharArray, val type: CharArray): SentenceState() {
+        fun next(recv: () -> Char): SentenceState {
+            val fields = mutableListOf<CharArray>()
+            var field = mutableListOf<Char>()
+            var count = 0
+            while (true) {
+                val char = recv()
+                count++
+
+                if (char == Sentence.FIELD_DELIMITER) {
+                    fields.add(field.toCharArray())
+                    field = mutableListOf<Char>()
+                    continue
+                }
+                if (char == Sentence.CHECKSUM_DELIMITER) {
+                    fields.add(field.toCharArray())
+                    return SentenceState.Checksum(talker, type, fields.toTypedArray())
+                }
+                // We've seen 7 chars from previous states
+                if ((count + 7) > MAXIMUM_SENTENCE_LENGTH) {
+                    return SentenceState.Prefix()
+                }
+
+                field.add(char)
+            }
+        }
+    }
+
+    internal class Checksum(val talker: CharArray, val type: CharArray, val fields: Array<CharArray>): SentenceState() {
+        fun next(recv: () -> Char): SentenceState {
+            // TODO: validate the checksum
+            @Suppress("UNUSED_VARIABLE")
+            val checksum = charArrayOf(recv(), recv())
+            return SentenceState.Complete(talker, type, fields)
+        }
+    }
+
+    internal class Complete(val talker: CharArray, val type: CharArray, val fields: Array<CharArray>): SentenceState()
+}

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -93,4 +93,14 @@ class GpsTest {
 
         Assert.assertEquals(expected, gsa)
     }
+
+    @Test
+    fun testEmptyGgaSentence() {
+        val expected = GpsFix(OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC), null, '0', 1, null, null, null)
+
+        val gps = Gps({ '?' }, { })
+        val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "", "", "", "", "0", "01", "", "", "", "", "", "", "")))
+
+        Assert.assertEquals(expected, gsa)
+    }
 }

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -1,0 +1,96 @@
+package gps
+
+import gps.parser.Sentence
+import org.junit.Assert
+import org.junit.Test
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
+
+class GpsTest {
+    @Test
+    fun testVtgSentence() {
+        val gps = Gps({ '?' }, { })
+        val vtg = gps.vtg(Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A")))
+
+        Assert.assertEquals(GpsGroundVelocity(165.48, 0.03, 'A'), vtg)
+        Assert.assertTrue("Mode should be Autonomous", vtg.mode == GpsGroundVelocity.MODE_AUTONOMOUS)
+    }
+
+    @Test
+    fun testRmcSentence() {
+        val time = OffsetDateTime.of(2006, 4, 26, 6, 49, 51, 0, ZoneOffset.UTC)
+        val position = GpsPosition(latitude = 2307.1256, longitude = 12016.4438)
+        val expectedGpsNavInfo = GpsNavInfo(time, true, position, 0.03, 165.48, 'A')
+
+        val gps = Gps({ '?' }, { })
+        val rmc = gps.rmc(Sentence("GP", "RMC", arrayOf("064951.000", "A", "2307.1256", "N", "12016.4438", "E", "0.03", "165.48", "260406", "3.05", "W", "A")))
+
+        Assert.assertEquals(expectedGpsNavInfo, rmc)
+        Assert.assertTrue("Mode should be 'Autonomous'", rmc.mode == GpsNavInfo.MODE_AUTONOMOUS)
+        Assert.assertTrue("Status should be 'Valid'", rmc.valid)
+    }
+
+    @Test
+    fun testGsvSentence1() {
+        val channel1 = GpsSatelliteMessage(29, 36,  29, 42)
+        val channel2 = GpsSatelliteMessage(21, 46, 314, 43)
+        val channel3 = GpsSatelliteMessage(26, 44,  20, 43)
+        val channel4 = GpsSatelliteMessage(15, 21, 321, 39)
+        val expectedGsv = GpsSatellitesInView(3, 1, 9, channel1, channel2, channel3, channel4)
+
+        val gps = Gps({ '?' }, { })
+        val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "1", "09", "29", "36", "029", "42", "21", "46", "314", "43", "26", "44", "020", "43", "15", "21", "321", "39")))
+
+        Assert.assertEquals(expectedGsv, gsv)
+    }
+
+    @Test
+    fun testGsvSentence2() {
+        val channel1 = GpsSatelliteMessage(18, 26, 314, 40)
+        val channel2 = GpsSatelliteMessage( 9, 57, 170, 44)
+        val channel3 = GpsSatelliteMessage( 6, 20, 229, 37)
+        val channel4 = GpsSatelliteMessage(10, 26,  84, 37)
+        val expectedGsv = GpsSatellitesInView(3, 2, 9, channel1, channel2, channel3, channel4)
+
+        val gps = Gps({ '?' }, { })
+        val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "2", "09", "18", "26", "314", "40", "09", "57", "170", "44", "06", "20", "229", "37", "10", "26", "084", "37")))
+
+        Assert.assertEquals(expectedGsv, gsv)
+    }
+
+    @Test
+    fun testGsvSentence3() {
+        val channel1 = GpsSatelliteMessage(7, null,  null, 26)
+        val expectedGsv = GpsSatellitesInView(3, 3, 9, channel1)
+
+        val gps = Gps({ '?' }, { })
+        val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "3", "09", "07", "", "", "26")))
+
+        Assert.assertEquals(expectedGsv, gsv)
+    }
+
+    @Test
+    fun testGsaSentence() {
+        val expectedGsa = GpsActiveSatellites('A', '3', GpsChannelArray(intArrayOf(29, 21, 26, 15, 18, 9, 6, 10)), GpsDilutionOfPrecision(2.32, 0.95, 2.11))
+
+        val gps = Gps({ '?' }, { })
+        val gsa = gps.gsa(Sentence("GP", "GSA", arrayOf("A", "3", "29", "21", "26", "15", "18", "09", "06", "10", "", "", "", "", "2.32", "0.95", "2.11")))
+
+        Assert.assertEquals(expectedGsa, gsa)
+        Assert.assertTrue("Mode 1 should be 'Automatic'", gsa.mode1 == GpsActiveSatellites.AUTOMATIC_MODE)
+        Assert.assertTrue("Mode 2 should be '3D (≧4 SVs used)'", gsa.mode2 == GpsActiveSatellites.MODE_3D)
+    }
+
+    @Test
+    fun testGgaSentence() {
+        val time = OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC)
+        val position = GpsPosition(latitude = 2307.1256, longitude = 12016.4438)
+        val expected = GpsFix(time, position, '1', 8, GpsDilutionOfPrecision(horizontal = 0.95), 39.9, 17.8)
+
+        val gps = Gps({ '?' }, { })
+        val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "2307.1256", "N", "12016.4438", "E", "1", "8", "0.95", "39.9", "M", "17.8", "M", "", "")))
+
+        Assert.assertEquals(expected, gsa)
+    }
+}

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -103,4 +103,48 @@ class GpsTest {
 
         Assert.assertEquals(expected, gsa)
     }
+
+    @Test
+    fun testRmcSentenceWithoutLock() {
+        val time = OffsetDateTime.of(2006, 4, 26, 6, 49, 51, 0, ZoneOffset.UTC)
+        val expectedGpsNavInfo = GpsNavInfo(time, false, null, null, null, 'N')
+
+        val gps = Gps({ '?' }, { })
+        val rmc = gps.rmc(Sentence("GP", "RMC", arrayOf("064951.000", "V", "", "", "", "", "", "", "260406", "", "", "N")))
+
+        Assert.assertEquals(expectedGpsNavInfo, rmc)
+        Assert.assertFalse("Status should NOT be 'Valid'", rmc.valid)
+    }
+
+    @Test
+    fun testGsvSentenceWithoutLock() {
+        val expectedGsv = GpsSatellitesInView(1, 1, 0, null)
+
+        val gps = Gps({ '?' }, { })
+        val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("1", "1", "00")))
+
+        Assert.assertEquals(expectedGsv, gsv)
+    }
+
+    @Test
+    fun testGsaSentenceWithoutLock() {
+        val expectedGsa = GpsActiveSatellites('A', '1', GpsChannelArray(intArrayOf()), GpsDilutionOfPrecision())
+
+        val gps = Gps({ '?' }, { })
+        val gsa = gps.gsa(Sentence("GP", "GSA", arrayOf("A", "1", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "")))
+
+        Assert.assertEquals(expectedGsa, gsa)
+        Assert.assertTrue("Mode 1 should be 'Automatic'", gsa.mode1 == GpsActiveSatellites.AUTOMATIC_MODE)
+        Assert.assertTrue("Mode 2 should be N/A", gsa.mode2 == GpsActiveSatellites.FIX_NOT_AVAILABLE)
+    }
+
+    @Test
+    fun testGgaSentenceWithoutLock() {
+        val expected = GpsFix(OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC), null, '0', 0, null, null, 0.0)
+
+        val gps = Gps({ '?' }, { })
+        val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "", "", "", "", "0", "00", "", "", "M", "0.0", "M", "", "0000")))
+
+        Assert.assertEquals(expected, gsa)
+    }
 }

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
@@ -1,0 +1,48 @@
+package gps.parser
+
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class SentenceParserTest(private val message: String) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() : Collection<Array<String>> {
+            return listOf(
+                // From the FGPMMOPA6H GPS Standalone Module datasheet
+                arrayOf("\$GPGGA,064951.000,2307.1256,N,12016.4438,E,1,8,0.95,39.9,M,17.8,M,,*63"),
+                arrayOf("\$GPGSA,A,3,29,21,26,15,18,09,06,10,,,,,2.32,0.95,2.11*00"),
+                arrayOf("\$GPGSV,3,1,09,29,36,029,42,21,46,314,43,26,44,020,43,15,21,321,39*7D"),
+                arrayOf("\$GPGSV,3,2,09,18,26,314,40,09,57,170,44,06,20,229,37,10,26,084,37*77"),
+                arrayOf("\$GPGSV,3,3,09,07,,,26*73"),
+                arrayOf("\$GPRMC,064951.000,A,2307.1256,N,12016.4438,E,0.03,165.48,260406,3.05,W,A*2C"),
+                arrayOf("\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A*36"),
+                // Courtesy of Wikipedia
+                arrayOf("\$GPAAM,A,A,0.10,N,WPTNME*32"),
+                arrayOf("\$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76"),
+                arrayOf("\$GPGSA,A,3,10,07,05,02,29,04,08,13,,,,,1.72,1.03,1.38*0A"),
+                arrayOf("\$GPGSV,3,1,11,10,63,137,17,07,61,098,15,05,59,290,20,08,54,157,30*70"),
+                arrayOf("\$GPGSV,3,2,11,02,39,223,19,13,28,070,17,26,23,252,,04,14,186,14*79"),
+                arrayOf("\$GPGSV,3,3,11,29,09,301,24,16,09,020,,36,,,*76"),
+                arrayOf("\$GPRMC,092750.000,A,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A*43"),
+                arrayOf("\$GPGGA,092751.000,5321.6802,N,00630.3371,W,1,8,1.03,61.7,M,55.3,M,,*75"),
+                arrayOf("\$GPGSA,A,3,10,07,05,02,29,04,08,13,,,,,1.72,1.03,1.38*0A"),
+                arrayOf("\$GPGSV,3,1,11,10,63,137,17,07,61,098,15,05,59,290,20,08,54,157,30*70"),
+                arrayOf("\$GPGSV,3,2,11,02,39,223,16,13,28,070,17,26,23,252,,04,14,186,15*77"),
+                arrayOf("\$GPGSV,3,3,11,29,09,301,24,16,09,020,,36,,,*76")
+            )
+        }
+    }
+
+    @Test(timeout = 10000)
+    fun parseMessage() {
+        val chars = message.toCharArray()
+        var count = 0
+        val parser = SentenceParser({ chars[count++] })
+        val sentence = parser.nextMessage()
+        Assert.assertEquals(sentence.toString(), message)
+    }
+}

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
@@ -46,3 +46,40 @@ class SentenceParserTest(private val message: String) {
         Assert.assertEquals(sentence.toString(), message)
     }
 }
+
+@RunWith(Parameterized::class)
+class SentenceParserEdgeCasesTest(msg: String, private val expected: String, private val message: String) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() : Collection<Array<String>> {
+            return listOf(
+                // A few edge cases
+                arrayOf(
+                    "Sentence ending with 0x0D0A",
+                    "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A*36",
+                    "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A" + String(charArrayOf(0x0D.toChar(), 0x0A.toChar()))
+                ),
+                arrayOf(
+                    "Sentence ending with 0x0D",
+                    "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A*36",
+                    "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A" + String(charArrayOf(0x0D.toChar()))
+                ),
+                arrayOf(
+                    "Sentence ending with 0x0A",
+                    "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A*36",
+                    "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A" + String(charArrayOf(0x0A.toChar()))
+                )
+            )
+        }
+    }
+
+    @Test()
+    fun parseMessage() {
+        val chars = message.toCharArray()
+        var count = 0
+        val parser = SentenceParser({ chars[count++] })
+        val sentence = parser.nextMessage()
+        Assert.assertEquals(expected, sentence.toString())
+    }
+}

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceTest.kt
@@ -1,0 +1,18 @@
+package gps.parser
+
+import org.junit.Assert
+import org.junit.Test
+
+class SentenceTest {
+    @Test
+    fun sentenceChecksumIsCorrect() {
+        val s = Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A"))
+        Assert.assertTrue(s.checksum == 54.toChar())
+    }
+
+    @Test
+    fun sentenceStringRepresentationIsCorrect() {
+        val s = Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A"))
+        Assert.assertEquals(s.toString(), "\$GPVTG,165.48,T,,M,0.03,N,0.06,K,A*36")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include "core"
 include "cli"
+include "gps"
 include "microcontrollers"
 
 rootProject.name = "boat"


### PR DESCRIPTION
Closes #18

This PR implements a rudimentary GPS parser (limited to GGA, GSA, GSV, RMC, and VTG sentences). The parser here is loosely based off the parser for microcontroller messages but this application of the parser is a bit lax about its parsing. For example, the parser does not care that messages are separated by `0x0D0A`, it will simply skip characters between the end of one message and the start of the next message `0x24`. This parser does also not handle messages that have special encapsulation in them, seeing as none of the sentences needed for #18 had them (that is, the start of a message is assumed to always be `0x24`).

The accuracy of this implementation is based off of these references:

- [NMEA 0183 - Wikipedia](https://en.wikipedia.org/wiki/NMEA_0183)
- [FGPMMOPA6H GPS Standalone Module datasheet](https://cdn-shop.adafruit.com/datasheets/GlobalTop-FGPMMOPA6H-Datasheet-V0A.pdf)
- [GPS - NMEA sentence information](http://aprs.gids.nl/nmea/)

Example usage of the parser:

```kt
val recv = // a function that reads one character off the serial line at a time
val parser = SentenceParser(recv)
val sentence = parser.nextMessage()
// Access sentence.talker, sentence.type, sentence.fields
```

Example usage of the `Gps` module:

```kt
val recv = // a function that reads one character off the serial line at a time
val gps = Gps(recv, { msg -> /* ??? */ })
// Invoke `Gps#poll` from a separate thread ideally
gps.poll()
```

To-do:

- [x] Parse NMEA 0183 sentences
- [x] Document the parser and data classes

The ability to log things to a database will be coming in a separate PR (as it's also needed for #29 and is a fair bit of work). The "extract data from the NMEA sentences and package as a payload to be sent over wireless during next interaction" requirement will also be fulfilled in a separate PR.