### PR TITLE
Add custom message type for wireless link received messages

### DIFF
--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -71,17 +71,13 @@ fun main(args: Array<String>) {
 
     val payloads = Observable.interval(1, TimeUnit.SECONDS)
         .observeOn(Schedulers.io())
-        .map {
-            val message = wirelessMicrocontroller.receive()
-            Logger.debug("Wireless received ${message.bytes}")
-            message.payload
-        }
+        .map { wirelessMicrocontroller.receive() }
 
     val motions = payloads
         .observeOn(Schedulers.computation())
-        .filter { it.first() != 0.toByte() }
-        .map { bytes ->
-            val msg = DynamicMessage.parseFrom(schema, bytes.sliceArray(1..(bytes.lastIndex - 2)))
+        .filter { it.containsMessage }
+        .map { message ->
+            val msg = DynamicMessage.parseFrom(schema, message.body)
             val msgDoubleField = { name: String ->
                 msg
                     .getField(schema.fields.first { it.name == name })

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkMicrocontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkMicrocontroller.kt
@@ -14,8 +14,8 @@ class WirelessLinkMicrocontroller(override val lock: Lock, override val recv: ()
         return writeMessage(Message(0x00, byteArrayOf(0x00)))
     }
 
-    fun receive(): Message {
-        return writeMessage(Message(0x03, byteArrayOf(0x00)))
+    fun receive(): WirelessLinkReceiveMessage {
+        return WirelessLinkReceiveMessage(writeMessage(Message(0x03, byteArrayOf(0x00))))
     }
 
     fun send(bytes: ByteArray): Message {

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkReceiveMessage.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkReceiveMessage.kt
@@ -1,0 +1,17 @@
+package microcontrollers
+
+import java.nio.ByteBuffer
+
+class WirelessLinkReceiveMessage(message: Message) {
+    val containsMessage = message.payload.first() == 1.toByte()
+
+    val body = message.payload.sliceArray(1..61)
+
+    val rssi = message.payload.sliceArray((message.payload.lastIndex - 1)..message.payload.lastIndex).toInt()
+
+    internal val bytes = message.bytes
+
+    private fun ByteArray.toInt(): Int {
+        return ByteBuffer.wrap(this).short.toInt()
+    }
+}

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/WirelessLinkReceiveMessageTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/WirelessLinkReceiveMessageTest.kt
@@ -1,0 +1,30 @@
+package microcontrollers
+
+import org.junit.Assert
+import org.junit.Test
+
+class WirelessLinkReceiveMessageTest {
+    @Test
+    fun testMessageContainsMessage() {
+        val message = WirelessLinkReceiveMessage(
+            Message(0x03, byteArrayOf(0x01) + ByteArray(61, { 42 }) + byteArrayOf(0x00, 0x72)))
+
+        Assert.assertTrue("Message.containsMessage should be true", message.containsMessage)
+    }
+
+    @Test
+    fun testMessageBodyDoesContainTheCorrectBytes() {
+        val message = WirelessLinkReceiveMessage(
+            Message(0x03, byteArrayOf(0x01) + ByteArray(61, { 42 }) + byteArrayOf(0x00, 0x72)))
+
+        Assert.assertArrayEquals(ByteArray(61, { 42 }), message.body)
+    }
+
+    @Test
+    fun testMessageRssiIsValid() {
+        val message = WirelessLinkReceiveMessage(
+            Message(0x03, byteArrayOf(0x01) + ByteArray(61, { 42 }) + byteArrayOf(0x00, 0x72)))
+
+        Assert.assertEquals(114, message.rssi)
+    }
+}


### PR DESCRIPTION
This PR adds a message type for messages received by the wireless link: `WirelessLinkReceiveMessage`.

This class exposes direct access to the message data bit, its body, and its RSSI directly.