### PR TITLE
Hard-code Motion message size as 18 bytes

### DIFF
--- a/projects/core/src/main/kotlin/core/values/Motion.kt
+++ b/projects/core/src/main/kotlin/core/values/Motion.kt
@@ -4,7 +4,13 @@ import schemas.MotionProtobuf
 
 data class Motion(val surge: Double, val yaw: Double) {
     companion object {
+        const val MESSAGE_SIZE = 18
+
         fun decode(bytes: ByteArray): Motion {
+            if (bytes.size > MESSAGE_SIZE) {
+                return decode(bytes.take(MESSAGE_SIZE).toByteArray())
+            }
+
             val protobuf = MotionProtobuf.Motion.parseFrom(bytes)
             return Motion(protobuf.surge, protobuf.yaw)
         }


### PR DESCRIPTION
This PR fixes an issue with deserializing Protocol Buffer messages off the wireless link discovered yesterday. Where Protocol Buffer messages are being padded with zeros for transport in the 61 byte packet via the wireless link, we need to know where a message ends inside it.

This fixes the issue **temporarily** by hard-coding the size of a `Motion` message as 18 bytes. This is an awful fix but ¯\\\_(ツ)\_/¯. This will be replaced with something better eventually (e.g. length-prefixed messages).