### PR TITLE
Set propulsion output range to [-255, 255]

### DIFF
--- a/projects/core/src/main/kotlin/core/hardware/ScrewPropeller.kt
+++ b/projects/core/src/main/kotlin/core/hardware/ScrewPropeller.kt
@@ -8,7 +8,7 @@ class ScrewPropeller(val controller: PropulsionMicrocontroller, val index: Int) 
     override var speed: Double
         get() = s
         set(value) {
-            val output = rangeMap(value, -1.0..1.0, -255.0..255.0).toShort()
+            val output = rangeMap(value, -1.0..1.0, PropulsionMicrocontroller.OUTPUT_RANGE).toShort()
             when (index) {
                 0 -> controller.setSpeed(output, 0)
                 1 -> controller.setSpeed(0, output)

--- a/projects/core/src/main/kotlin/core/hardware/ScrewPropeller.kt
+++ b/projects/core/src/main/kotlin/core/hardware/ScrewPropeller.kt
@@ -8,7 +8,7 @@ class ScrewPropeller(val controller: PropulsionMicrocontroller, val index: Int) 
     override var speed: Double
         get() = s
         set(value) {
-            val output = rangeMap(value, -1.0..1.0, 0.0..255.0).toShort()
+            val output = rangeMap(value, -1.0..1.0, -255.0..255.0).toShort()
             when (index) {
                 0 -> controller.setSpeed(output, 0)
                 1 -> controller.setSpeed(0, output)

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/PropulsionMicrocontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/PropulsionMicrocontroller.kt
@@ -4,6 +4,10 @@ import java.nio.ByteBuffer
 import java.util.concurrent.locks.Lock
 
 class PropulsionMicrocontroller(override val lock: Lock, override val recv: () -> Byte, override val send: (ByteArray) -> Unit) : Microcontroller {
+    companion object {
+        val OUTPUT_RANGE = -255.0..255.0
+    }
+
     override val payloadSizes: Map<Byte, Int> = mapOf(
         0x10.toByte() to 1,
         0x13.toByte() to 4,


### PR DESCRIPTION
See also: [Command `0x13` – Set Motor Speeds](https://github.com/LakeMaps/microcontrollers/wiki/Propulsion-Microcontroller-API#command-0x13--set-motor-speeds)

This extends the output range for the propellers to [-255, 255].