### PR TITLE
Set speed to zero before shutdown

### DIFF
--- a/projects/core/src/main/kotlin/core/Boat.kt
+++ b/projects/core/src/main/kotlin/core/Boat.kt
@@ -37,6 +37,8 @@ class Boat(private val broadcast: Broadcast, private val props: Pair<Propeller, 
                 break
             }
         }
+
+        tick(speed(Motion(0.0, 0.0)))
     }
 
     private fun tick(outputs: Pair<Double, Double>) {


### PR DESCRIPTION
This PR updates `Boat#shutdown()` to zero out the props before returning.