### PR TITLE
Add JMH project and initial benchmarks

### DIFF
--- a/projects/jmh/build.gradle.kts
+++ b/projects/jmh/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
 apply {
     plugin("kotlin")
+    plugin("kotlin-kapt")
 }
 
 dependencies {
@@ -20,6 +21,7 @@ dependencies {
     compile(project(":core"))
     compile(project(":microcontrollers"))
     compile("org.openjdk.jmh:jmh-core:1.18")
+    kapt("org.openjdk.jmh:jmh-generator-annprocess:1.18")
 }
 
 configure<ApplicationPluginConvention> {

--- a/projects/jmh/build.gradle.kts
+++ b/projects/jmh/build.gradle.kts
@@ -1,0 +1,27 @@
+buildscript {
+    repositories {
+        gradleScriptKotlin()
+    }
+    dependencies {
+        classpath(kotlinModule("gradle-plugin"))
+    }
+}
+
+plugins {
+    application
+}
+
+apply {
+    plugin("kotlin")
+}
+
+dependencies {
+    compile(kotlinModule("stdlib"))
+    compile(project(":core"))
+    compile(project(":microcontrollers"))
+    compile("org.openjdk.jmh:jmh-core:1.18")
+}
+
+configure<ApplicationPluginConvention> {
+    mainClassName = "org.openjdk.jmh.Main"
+}

--- a/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
@@ -1,7 +1,11 @@
 package jmh
 
 import core.Boat
+import core.hardware.Propeller
+import core.hardware.ScrewPropeller
 import core.values.Motion
+import microcontrollers.PropulsionMicrocontroller
+import microcontrollers.WirelessLinkMicrocontroller
 
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.BenchmarkMode
@@ -12,10 +16,15 @@ import org.openjdk.jmh.annotations.OutputTimeUnit
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import rx.Observable
 import rx.broadcast.InMemoryBroadcast
+import rx.schedulers.Schedulers
 import rx.schedulers.TestScheduler
 
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
 
 @Fork(1)
 @Measurement(iterations = 20)
@@ -41,5 +50,82 @@ open class BoatBenchmark {
         scheduler.advanceTimeBy(boat.SLEEP_DURATION_MS, TimeUnit.MILLISECONDS)
 
         return Pair(props.first, props.second)
+    }
+
+    class Foo(private val prop: Propeller, private val callback: (Double) -> Unit): Propeller {
+        override var speed: Double
+            get() = prop.speed
+            set(value) {
+                prop.speed = value
+                callback(prop.speed)
+            }
+    }
+
+    @Benchmark
+    fun core(blackhole: Blackhole) {
+        val counter = CountDownLatch(4)
+
+        val motion1 = byteArrayOf(
+            0x09.toByte(), 0xe1.toByte(), 0x7a.toByte(),
+            0x14.toByte(), 0xae.toByte(), 0x47.toByte(),
+            0xe1.toByte(), 0xda.toByte(), 0x3f.toByte(),
+            0x11.toByte(), 0xb8.toByte(), 0x1e.toByte(),
+            0x85.toByte(), 0xeb.toByte(), 0x51.toByte(),
+            0xb8.toByte(), 0xce.toByte(), 0x3f.toByte())
+        val motion2 = byteArrayOf(
+            0x09.toByte(), 0xb8.toByte(), 0x1e.toByte(),
+            0x85.toByte(), 0xeb.toByte(), 0x51.toByte(),
+            0xb8.toByte(), 0xce.toByte(), 0x3f.toByte(),
+            0x11.toByte(), 0xe1.toByte(), 0x7a.toByte(),
+            0x14.toByte(), 0xae.toByte(), 0x47.toByte(),
+            0xe1.toByte(), 0xda.toByte(), 0x3f.toByte())
+        val wsSerialPort = NullSerialPort(blackhole,
+            // Bytes for the 1st receive
+            byteArrayOf(0xAA.toByte(), 0x03, 0x01) + motion1 + ByteArray(45, { 0 }) + byteArrayOf(0xFF.toByte(), 0x13.toByte()) +
+            // Bytes for the 2nd receive
+            byteArrayOf(0xAA.toByte(), 0x03, 0x01) + motion2 + ByteArray(45, { 0 }) + byteArrayOf(0xD5.toByte(), 0xdb.toByte())
+        )
+        val psSerialPort = NullSerialPort(blackhole, byteArrayOf(
+            // 1st response from both
+            0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte(),
+            0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte(),
+            // 2nd response from both
+            0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte(),
+            0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte(),
+            // Boat#shutdown zeros the props
+            0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte(),
+            0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte()
+        ))
+        val wirelessMicrocontroller = WirelessLinkMicrocontroller(ReentrantLock(), wsSerialPort::recv, wsSerialPort::send)
+        val propulsionMicrocontroller = PropulsionMicrocontroller(ReentrantLock(), psSerialPort::recv, psSerialPort::send)
+
+        val props = Pair(
+            Foo(ScrewPropeller(propulsionMicrocontroller, 0), { counter.countDown() }),
+            Foo(ScrewPropeller(propulsionMicrocontroller, 1), { counter.countDown() }))
+
+        val boatClockScheduler = TestScheduler()
+        val wirelessClockScheduler = TestScheduler()
+        val broadcast = InMemoryBroadcast()
+        val boat = Boat(broadcast, props)
+
+        boat.start(io = Schedulers.io(), clock = boatClockScheduler)
+
+        val payloads = Observable.interval(1, TimeUnit.SECONDS, wirelessClockScheduler)
+            .map { wirelessMicrocontroller.receive() }
+
+        val motions = payloads
+            .filter { it.containsMessage }
+            .map { Motion.decode(it.body) }
+
+        motions.subscribe({ broadcast.send(it).subscribe() }, { throw RuntimeException(it) })
+
+        wirelessClockScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+        boatClockScheduler.advanceTimeBy(boat.SLEEP_DURATION_MS, TimeUnit.MILLISECONDS)
+
+        wirelessClockScheduler.advanceTimeBy(1, TimeUnit.SECONDS)
+        boatClockScheduler.advanceTimeBy(boat.SLEEP_DURATION_MS, TimeUnit.MILLISECONDS)
+
+        counter.await()
+        boat.shutdown()
     }
 }

--- a/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
@@ -1,0 +1,53 @@
+package jmh
+
+import core.Boat
+import core.hardware.Propeller
+import core.values.Motion
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import rx.broadcast.InMemoryBroadcast
+import rx.schedulers.TestScheduler
+
+import java.util.concurrent.TimeUnit
+
+@Fork(1)
+@Measurement(iterations = 20)
+@Warmup(iterations = 0)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class BoatBenchmark {
+    class NullPropeller : Propeller {
+        private var s = 0.0
+        override var speed
+            get() = s
+            set(value) { s = value }
+    }
+
+    var surge = Math.PI
+
+    var yaw = Math.PI
+
+    @Benchmark
+    fun tick(): Pair<NullPropeller, NullPropeller> {
+        val broadcast = InMemoryBroadcast()
+        val scheduler = TestScheduler()
+        val props = Pair(NullPropeller(), NullPropeller())
+        val boat = Boat(broadcast, props)
+
+        boat.start(io = scheduler, clock = scheduler)
+
+        broadcast.send(Motion(surge, yaw)).subscribe()
+        scheduler.advanceTimeBy(boat.SLEEP_DURATION_MS, TimeUnit.MILLISECONDS)
+
+        return Pair(props.first, props.second)
+    }
+}

--- a/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
@@ -1,7 +1,6 @@
 package jmh
 
 import core.Boat
-import core.hardware.Propeller
 import core.values.Motion
 
 import org.openjdk.jmh.annotations.Benchmark
@@ -25,13 +24,6 @@ import java.util.concurrent.TimeUnit
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 open class BoatBenchmark {
-    class NullPropeller : Propeller {
-        private var s = 0.0
-        override var speed
-            get() = s
-            set(value) { s = value }
-    }
-
     var surge = Math.PI
 
     var yaw = Math.PI

--- a/projects/jmh/src/main/kotlin/jmh/MicrocontrollerBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/MicrocontrollerBenchmark.kt
@@ -1,0 +1,70 @@
+package jmh
+
+import microcontrollers.Message
+import microcontrollers.PropulsionMicrocontroller
+import microcontrollers.WirelessLinkMicrocontroller
+import microcontrollers.WirelessLinkReceiveMessage
+
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+
+class MockSerialPort(
+    private val bytes: ByteArray,
+    private var count: Int = 0
+) {
+    fun recv() = bytes[count++]
+    fun send(bytes: ByteArray) { /* empty */ }
+}
+
+@Fork(1)
+@Measurement(iterations = 20)
+@Warmup(iterations = 0)
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+open class MicrocontrollerBenchmark {
+    @Benchmark
+    fun resetPropulsionMicrocontroller(): Message {
+        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E))
+        val microcontroller = PropulsionMicrocontroller(ReentrantLock(), serial::recv, serial::send)
+        return microcontroller.reset()
+    }
+
+    @Benchmark
+    fun setSpeedPropulsionMicrocontroller(): Message {
+        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte()))
+        val microcontroller = PropulsionMicrocontroller(ReentrantLock(), serial::recv, serial::send)
+        return microcontroller.setSpeed(128, 0)
+    }
+
+    @Benchmark
+    fun resetWirelessLinkMicrocontroller(): Message {
+        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D))
+        val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
+        return microcontroller.reset()
+    }
+
+    @Benchmark
+    fun receiveWirelessLinkMicrocontroller(): WirelessLinkReceiveMessage {
+        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x33 }) + byteArrayOf(0x06, 0x9F.toByte()))
+        val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
+        return microcontroller.receive()
+    }
+
+    @Benchmark
+    fun sendWirelessLinkMicrocontroller(): Message {
+        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x04, 0x01, 0xA6.toByte(), 0xB8.toByte()))
+        val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
+        return microcontroller.send(ByteArray(61, { 0x42 }))
+    }
+}

--- a/projects/jmh/src/main/kotlin/jmh/MicrocontrollerBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/MicrocontrollerBenchmark.kt
@@ -19,15 +19,6 @@ import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 
-class MockSerialPort(
-    private val blackhole: Blackhole,
-    private val bytes: ByteArray,
-    private var count: Int = 0
-) {
-    fun recv() = bytes[count++]
-    fun send(bytes: ByteArray) = bytes.forEach { blackhole.consume(it) }
-}
-
 @Fork(1)
 @Measurement(iterations = 20)
 @Warmup(iterations = 0)
@@ -37,35 +28,35 @@ class MockSerialPort(
 open class MicrocontrollerBenchmark {
     @Benchmark
     fun resetPropulsionMicrocontroller(blackhole: Blackhole): Message {
-        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E))
+        val serial = NullSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E))
         val microcontroller = PropulsionMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.reset()
     }
 
     @Benchmark
     fun setSpeedPropulsionMicrocontroller(blackhole: Blackhole): Message {
-        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte()))
+        val serial = NullSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte()))
         val microcontroller = PropulsionMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.setSpeed(128, 0)
     }
 
     @Benchmark
     fun resetWirelessLinkMicrocontroller(blackhole: Blackhole): Message {
-        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D))
+        val serial = NullSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D))
         val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.reset()
     }
 
     @Benchmark
     fun receiveWirelessLinkMicrocontroller(blackhole: Blackhole): WirelessLinkReceiveMessage {
-        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x33 }) + byteArrayOf(0x06, 0x9F.toByte()))
+        val serial = NullSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x33 }) + byteArrayOf(0x06, 0x9F.toByte()))
         val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.receive()
     }
 
     @Benchmark
     fun sendWirelessLinkMicrocontroller(blackhole: Blackhole): Message {
-        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x04, 0x01, 0xA6.toByte(), 0xB8.toByte()))
+        val serial = NullSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x04, 0x01, 0xA6.toByte(), 0xB8.toByte()))
         val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.send(ByteArray(61, { 0x42 }))
     }

--- a/projects/jmh/src/main/kotlin/jmh/MicrocontrollerBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/MicrocontrollerBenchmark.kt
@@ -14,16 +14,18 @@ import org.openjdk.jmh.annotations.OutputTimeUnit
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 
 class MockSerialPort(
+    private val blackhole: Blackhole,
     private val bytes: ByteArray,
     private var count: Int = 0
 ) {
     fun recv() = bytes[count++]
-    fun send(bytes: ByteArray) { /* empty */ }
+    fun send(bytes: ByteArray) = bytes.forEach { blackhole.consume(it) }
 }
 
 @Fork(1)
@@ -34,36 +36,36 @@ class MockSerialPort(
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 open class MicrocontrollerBenchmark {
     @Benchmark
-    fun resetPropulsionMicrocontroller(): Message {
-        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E))
+    fun resetPropulsionMicrocontroller(blackhole: Blackhole): Message {
+        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x10, 0x00, 0x79, 0x2E))
         val microcontroller = PropulsionMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.reset()
     }
 
     @Benchmark
-    fun setSpeedPropulsionMicrocontroller(): Message {
-        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte()))
+    fun setSpeedPropulsionMicrocontroller(blackhole: Blackhole): Message {
+        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x13, 0x00, 0x80.toByte(), 0x00, 0x00, 0xB6.toByte(), 0xF8.toByte()))
         val microcontroller = PropulsionMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.setSpeed(128, 0)
     }
 
     @Benchmark
-    fun resetWirelessLinkMicrocontroller(): Message {
-        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D))
+    fun resetWirelessLinkMicrocontroller(blackhole: Blackhole): Message {
+        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x00, 0x00, 0x7A, 0x5D))
         val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.reset()
     }
 
     @Benchmark
-    fun receiveWirelessLinkMicrocontroller(): WirelessLinkReceiveMessage {
-        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x33 }) + byteArrayOf(0x06, 0x9F.toByte()))
+    fun receiveWirelessLinkMicrocontroller(blackhole: Blackhole): WirelessLinkReceiveMessage {
+        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x33 }) + byteArrayOf(0x06, 0x9F.toByte()))
         val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.receive()
     }
 
     @Benchmark
-    fun sendWirelessLinkMicrocontroller(): Message {
-        val serial = MockSerialPort(byteArrayOf(0xAA.toByte(), 0x04, 0x01, 0xA6.toByte(), 0xB8.toByte()))
+    fun sendWirelessLinkMicrocontroller(blackhole: Blackhole): Message {
+        val serial = MockSerialPort(blackhole, byteArrayOf(0xAA.toByte(), 0x04, 0x01, 0xA6.toByte(), 0xB8.toByte()))
         val microcontroller = WirelessLinkMicrocontroller(ReentrantLock(), serial::recv, serial::send)
         return microcontroller.send(ByteArray(61, { 0x42 }))
     }

--- a/projects/jmh/src/main/kotlin/jmh/NullPropeller.kt
+++ b/projects/jmh/src/main/kotlin/jmh/NullPropeller.kt
@@ -1,0 +1,12 @@
+package jmh
+
+import core.hardware.Propeller
+
+class NullPropeller: Propeller {
+    private var s = 0.0
+    override var speed
+        get() = s
+        set(value) {
+            s = value
+        }
+}

--- a/projects/jmh/src/main/kotlin/jmh/NullSerialPort.kt
+++ b/projects/jmh/src/main/kotlin/jmh/NullSerialPort.kt
@@ -1,0 +1,10 @@
+package jmh
+
+import org.openjdk.jmh.infra.Blackhole
+
+class NullSerialPort(private val blackhole: Blackhole, private val bytes: ByteArray) {
+    private var count: Int = 0
+
+    fun recv() = bytes[count++]
+    fun send(bytes: ByteArray) = bytes.forEach(blackhole::consume)
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 include "cli"
 include "core"
 include "gps"
+include "jmh"
 include "microcontrollers"
 
 rootProject.name = "boat"


### PR DESCRIPTION
This PR adds a new project dedicated to [JMH benchmarking][1] 🎉

JMH is a harness for building, running, and analysing micro/macro benchmarks written in languages targetting the JVM (e.g. [Kotlin][2]). We'll use this to profile the control software as needed.

  [1]:http://openjdk.java.net/projects/code-tools/jmh/
  [2]:https://kotlinlang.org

I've also added a few initial benchmarks to help us with diagnosing our control latency in #47.