### PR TITLE
Move logging into its own project

### DIFF
--- a/projects/cli/build.gradle.kts
+++ b/projects/cli/build.gradle.kts
@@ -17,6 +17,7 @@ apply {
 
 dependencies {
     compile(project(":core"))
+    compile(project(":log"))
     compile(project(":microcontrollers"))
     compile(kotlinModule("stdlib"))
     compile("com.fazecast:jSerialComm:1.3.11")

--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -5,6 +5,7 @@ package cli
 import core.Boat
 import core.hardware.ScrewPropeller
 import core.values.Motion
+import log.Log
 import microcontrollers.PropulsionMicrocontroller
 import microcontrollers.WirelessLinkMicrocontroller
 
@@ -13,7 +14,6 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 
 import com.fazecast.jSerialComm.SerialPort
-import org.pmw.tinylog.Logger
 import rx.Observable
 import rx.broadcast.InMemoryBroadcast
 import rx.schedulers.Schedulers
@@ -34,7 +34,7 @@ private fun serialPort(name: String, baudRate: Int = 115200): Triple<SerialPort,
 
 fun main(args: Array<String>) {
     if (!args.any()) {
-        System.err.println("Missing filename for wireless and prop serial ports")
+        Log.wtf { "Missing filename for wireless and prop serial ports" }
         return
     }
 
@@ -57,11 +57,11 @@ fun main(args: Array<String>) {
     val motions = payloads
         .observeOn(Schedulers.computation())
         .filter { it.containsMessage }
-        .doOnNext { Logger.info("RSSI\t${it.rssi}") }
+        .doOnNext { Log.d { "RSSI\t${it.rssi}" } }
         .map { Motion.decode(it.body) }
 
     motions.subscribe { motion ->
-        Logger.debug("Broadcasting $motion")
+        Log.d { "Broadcasting $motion" }
         broadcast.send(motion).subscribe()
     }
 

--- a/projects/log/build.gradle.kts
+++ b/projects/log/build.gradle.kts
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        gradleScriptKotlin()
+    }
+    dependencies {
+        classpath(kotlinModule("gradle-plugin"))
+    }
+}
+
+apply {
+    plugin("kotlin")
+}
+
+dependencies {
+    compile(kotlinModule("stdlib"))
+}

--- a/projects/log/src/main/kotlin/log/Log.kt
+++ b/projects/log/src/main/kotlin/log/Log.kt
@@ -1,0 +1,31 @@
+package log
+
+import java.time.LocalDateTime
+
+class Log {
+    enum class Level { NONE, ERROR, WARNING, DEBUG }
+
+    companion object {
+        val level = Level.valueOf(System.getenv("LOG") ?: "NONE")
+
+        fun wtf(msg: () -> String) {
+            when { level < Level.ERROR -> return }
+
+            System.err.println(formatted(msg))
+        }
+
+        fun w(msg: () -> String) {
+            when { level < Level.WARNING -> return }
+
+            System.err.println(formatted(msg))
+        }
+
+        fun d(msg: () -> String) {
+            when { level < Level.DEBUG -> return }
+
+            println(formatted(msg = msg))
+        }
+
+        internal inline fun formatted(msg: () -> String) = "$level,${LocalDateTime.now()}\t${msg()}"
+    }
+}

--- a/projects/microcontrollers/build.gradle.kts
+++ b/projects/microcontrollers/build.gradle.kts
@@ -16,6 +16,7 @@ apply {
 
 dependencies {
     compile(kotlinModule("stdlib"))
+    compile(project(":log"))
     testCompile("junit:junit:4.12")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
 }

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/ByteArrayExtensions.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/ByteArrayExtensions.kt
@@ -1,0 +1,3 @@
+package microcontrollers
+
+internal fun ByteArray.hex() = this.joinToString(separator = "") { it.hex() }

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/ByteExtensions.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/ByteExtensions.kt
@@ -1,0 +1,3 @@
+package microcontrollers
+
+internal fun Byte.hex() = Integer.toHexString(this.toInt()).takeLast(2).padStart(2, '0')

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/Message.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/Message.kt
@@ -14,6 +14,8 @@ class Message(val command: Byte, val payload: ByteArray) {
         bytes.sliceArray((bytes.lastIndex - 1)..bytes.lastIndex)
     }
 
+    override fun toString() = "Message(command=0x${command.hex()}, payload=0x${payload.hex()}, checksum=0x${checksum.hex()})"
+
     private fun crc16(bytes: ByteArray): ByteArray {
         var result: Int = 0
         for (b in bytes.map(Byte::toInt)) {

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/MessageState.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/MessageState.kt
@@ -1,5 +1,7 @@
 package microcontrollers
 
+import log.Log
+
 internal sealed class MessageState {
     class Started : MessageState() {
         fun next(recv: () -> Byte, buffer: (Byte) -> Unit): MessageState {
@@ -9,7 +11,7 @@ internal sealed class MessageState {
                 buffer(byte)
                 return MessageState.Command()
             } else {
-                // This isn't the byte we're looking for
+                Log.d { "Skipping 0x${byte.hex()} in search of message start byte" }
                 return MessageState.Started()
             }
         }
@@ -20,7 +22,7 @@ internal sealed class MessageState {
             buffer(command)
 
             if (!payloadSizes.containsKey(command)) {
-                // Invalid command received
+                Log.w { "Received Invalid command byte 0x${command.hex()}" }
                 return MessageState.Started()
             } else {
                 val payloadSize = payloadSizes[command]!!

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/Microcontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/Microcontroller.kt
@@ -1,5 +1,7 @@
 package microcontrollers
 
+import log.Log
+
 import java.nio.ByteBuffer
 import java.util.Arrays
 import java.util.concurrent.locks.Lock
@@ -38,7 +40,7 @@ internal interface Microcontroller {
                         return message
                     }
 
-                    System.err.println("Received corrupt message ${message}")
+                    Log.w { "Received incorrect checksum 0x${nextTwoBytes.hex()} for $message" }
                     MessageState.Started()
                 }
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ include "cli"
 include "core"
 include "gps"
 include "jmh"
+include "log"
 include "microcontrollers"
 
 rootProject.name = "boat"


### PR DESCRIPTION
This PR adds logging as its own project, exposing an API based on Android's [`Log`](https://developer.android.com/reference/android/util/Log.html) class.