### PR TITLE
Handle error messages when communicating with microcontrollers

### DIFF
--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkMicrocontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkMicrocontroller.kt
@@ -1,5 +1,6 @@
 package microcontrollers
 
+import log.Log
 import java.util.concurrent.locks.Lock
 
 class WirelessLinkMicrocontroller(override val lock: Lock, override val recv: () -> Byte, override val send: (ByteArray) -> Unit) : Microcontroller {
@@ -15,13 +16,30 @@ class WirelessLinkMicrocontroller(override val lock: Lock, override val recv: ()
     }
 
     fun receive(): WirelessLinkReceiveMessage {
-        return WirelessLinkReceiveMessage(writeMessage(Message(0x03, byteArrayOf(0x00))))
+        val req = Message(0x03, byteArrayOf(0x00))
+        val res = writeMessage(req)
+        return when (res.command.toInt()) {
+            0x03 -> WirelessLinkReceiveMessage(res)
+            else -> {
+                Log.w { "Incorrect response for $req, received $res" }
+                WirelessLinkReceiveMessage(Message(0x03, ByteArray(payloadSizes[0x03]!!, { 0 })))
+            }
+        }
     }
 
     fun send(bytes: ByteArray): Message {
         if (bytes.size > 61) {
             throw IllegalArgumentException("Message payload must be !> 61 bytes, ${bytes.size} given")
         }
-        return writeMessage(Message(0x04, bytes))
+
+        val req = Message(0x04, bytes)
+        val res = writeMessage(req)
+        return when (res.command.toInt()) {
+            0x04 -> res
+            else -> {
+                Log.w { "Incorrect response for $req, received $res" }
+                Message(0x04, byteArrayOf(0x00))
+            }
+        }
     }
 }

--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkReceiveMessage.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/WirelessLinkReceiveMessage.kt
@@ -2,7 +2,7 @@ package microcontrollers
 
 import java.nio.ByteBuffer
 
-class WirelessLinkReceiveMessage(message: Message) {
+class WirelessLinkReceiveMessage(private val message: Message) {
     val containsMessage = message.payload.first() == 1.toByte()
 
     val body = message.payload.sliceArray(1..61)
@@ -10,6 +10,8 @@ class WirelessLinkReceiveMessage(message: Message) {
     val rssi = message.payload.sliceArray((message.payload.lastIndex - 1)..message.payload.lastIndex).toInt()
 
     internal val bytes = message.bytes
+
+    override fun toString() = message.toString()
 
     private fun ByteArray.toInt(): Int {
         return ByteBuffer.wrap(this).short.toInt()

--- a/projects/microcontrollers/src/test/kotlin/microcontrollers/WirelessLinkMicrocontrollerTest.kt
+++ b/projects/microcontrollers/src/test/kotlin/microcontrollers/WirelessLinkMicrocontrollerTest.kt
@@ -55,4 +55,32 @@ class WirelessLinkMicrocontrollerTest {
         CollectionAssertionSession(sent).shouldBe(expectedSend.asIterable())
         CollectionAssertionSession(message.bytes.asIterable()).shouldBe(expectedRecv.asIterable())
     }
+
+    @Test(timeout = 10000)
+    fun receiveWithChecksumFailureDoesReturnAnEmptyMessage() {
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x0F, 0x01, 0x7A, 0x42)
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val microcontroller = WirelessLinkMicrocontroller(
+            ReentrantLock(), recv, { /* empty */ })
+
+        val message = microcontroller.receive()
+        CollectionAssertionSession(message.bytes.asIterable())
+            .shouldBe((byteArrayOf(0xAA.toByte(), 0x03) + ByteArray(64, { 0x00 }) + byteArrayOf(0x5D, 0xBC.toByte())).asIterable())
+    }
+
+    @Test(timeout = 10000)
+    fun sendWithChecksumFailureDoesReturnAnEmptyMessage() {
+        val expectedRecv = byteArrayOf(0xAA.toByte(), 0x0F, 0x01, 0x7A, 0x42)
+
+        var recvCallCount = 0
+        val recv = { expectedRecv[recvCallCount++] }
+        val microcontroller = WirelessLinkMicrocontroller(
+            ReentrantLock(), recv, { /* empty */ })
+
+        val message = microcontroller.send(ByteArray(61, { 0x42 }))
+        CollectionAssertionSession(message.bytes.asIterable())
+            .shouldBe(byteArrayOf(0xAA.toByte(), 0x04, 0x00, 0xB6.toByte(), 0x99.toByte()).asIterable())
+    }
 }


### PR DESCRIPTION
This PR updates the microcontrollers API to handle error messages (i.e. [`0x0F`][1] and [`0x1F`][2] commands).

Where we're using 115200bps, "invalid checksum" errors are noticeably more frequent (likely caused by _actual_ corruption on the serial line). That is, exchanges such as the example below are frequent:

```
DEBUG,2016-11-26T08:36:42.288	Sent Message(command=0x03, payload=0x00, checksum=0x2f0e)
DEBUG,2016-11-26T08:36:42.301	Received Message(command=0x0f, payload=0x01, checksum=0x7a42)
```

To remedy this issue, this PR updates the microcontrollers API to log and discard checksum errors, timeouts, and invalid speed range errors (the three currently available errors).

  [1]:https://github.com/LakeMaps/microcontrollers/wiki/Wireless-Communication-Microcontroller-API#command-0x0f--general-error-message
  [2]:https://github.com/LakeMaps/microcontrollers/wiki/Propulsion-Microcontroller-API#command-0x1f--general-error-message