### PR TITLE
Pass correct log level through to formatter function

### DIFF
--- a/projects/log/src/main/kotlin/log/Log.kt
+++ b/projects/log/src/main/kotlin/log/Log.kt
@@ -11,21 +11,21 @@ class Log {
         fun wtf(msg: () -> String) {
             when { level < Level.ERROR -> return }
 
-            System.err.println(formatted(msg))
+            System.err.println(formatted(Level.ERROR, msg))
         }
 
         fun w(msg: () -> String) {
             when { level < Level.WARNING -> return }
 
-            System.err.println(formatted(msg))
+            System.err.println(formatted(Level.WARNING, msg))
         }
 
         fun d(msg: () -> String) {
             when { level < Level.DEBUG -> return }
 
-            println(formatted(msg = msg))
+            println(formatted(Level.DEBUG, msg))
         }
 
-        internal inline fun formatted(msg: () -> String) = "$level,${LocalDateTime.now()}\t${msg()}"
+        internal inline fun formatted(level: Level, msg: () -> String) = "$level,${LocalDateTime.now()}\t${msg()}"
     }
 }


### PR DESCRIPTION
This PR fixes the log format, which incorrectly showed the current log level, not the level for the message.