### PR TITLE
Set propulsion output range to [-127, 127]

### DIFF
--- a/projects/microcontrollers/src/main/kotlin/microcontrollers/PropulsionMicrocontroller.kt
+++ b/projects/microcontrollers/src/main/kotlin/microcontrollers/PropulsionMicrocontroller.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.locks.Lock
 
 class PropulsionMicrocontroller(override val lock: Lock, override val recv: () -> Byte, override val send: (ByteArray) -> Unit) : Microcontroller {
     companion object {
-        val OUTPUT_RANGE = -255.0..255.0
+        val OUTPUT_RANGE = -127.0..127.0
     }
 
     override val payloadSizes: Map<Byte, Int> = mapOf(


### PR DESCRIPTION
Refs LakeMaps/microcontrollers#24 and LakeMaps/microcontrollers#25

This PR updates the output range for the propulsion microcontroller to [-127, 127].