### PR TITLE
Adjust wireless link polling and boat clock timing

### DIFF
--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -58,7 +58,7 @@ fun main(args: Array<String>) {
     Runtime.getRuntime().addShutdownHook(Thread({ boat.shutdown() }))
     boat.start(io = Schedulers.io(), clock = Schedulers.computation())
 
-    val payloads = Observable.interval(30, TimeUnit.MILLISECONDS)
+    val payloads = Observable.interval(boat.SLEEP_DURATION_MS, TimeUnit.MILLISECONDS)
         .observeOn(Schedulers.io())
         .map { wirelessMicrocontroller.receive() }
         .onBackpressureLatest()

--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -58,7 +58,7 @@ fun main(args: Array<String>) {
     Runtime.getRuntime().addShutdownHook(Thread({ boat.shutdown() }))
     boat.start(io = Schedulers.io(), clock = Schedulers.computation())
 
-    val payloads = Observable.interval(10, TimeUnit.MILLISECONDS)
+    val payloads = Observable.interval(30, TimeUnit.MILLISECONDS)
         .observeOn(Schedulers.io())
         .map { wirelessMicrocontroller.receive() }
         .onBackpressureLatest()

--- a/projects/core/src/main/kotlin/core/Boat.kt
+++ b/projects/core/src/main/kotlin/core/Boat.kt
@@ -13,7 +13,7 @@ import rx.subjects.PublishSubject
 import rx.subjects.Subject
 
 class Boat(private val broadcast: Broadcast, private val props: Pair<Propeller, Propeller>) {
-    val SLEEP_DURATION_MS = (System.getenv("SLEEP_DURATION_MS") ?: "16").toLong()
+    val SLEEP_DURATION_MS = 30L
 
     private val dead = AtomicBoolean()
 


### PR DESCRIPTION
Refs #57

This PR updates the wireless link polling interval and the boat's internal clock cycle to 30 ms.