### PR TITLE
Update GPS data to include units

### DIFF
--- a/projects/core/src/main/kotlin/core/Math.kt
+++ b/projects/core/src/main/kotlin/core/Math.kt
@@ -1,5 +1,0 @@
-package core
-
-fun dd(value: Float): Float {
-    return ((value / 100f).toInt() + ((value / 100f - (value / 100f).toInt()) / 0.6f))
-}

--- a/projects/core/src/main/kotlin/core/values/GpsValue.kt
+++ b/projects/core/src/main/kotlin/core/values/GpsValue.kt
@@ -1,6 +1,5 @@
 package core.values
 
-import core.dd
 import gps.GpsFix
 import gps.GpsNavInfo
 import schemas.GpsProtobuf
@@ -24,8 +23,8 @@ data class GpsValue(val horizontalDilutionOfPrecision: Float, val position: Posi
                 && speed != null
                 && course != null
             ) {
-                val position = Position(dd(longitude.toFloat()), dd(latitude.toFloat()), altitude.toFloat())
-                GpsValue(hdop.toFloat(), position, Velocity(speed.toFloat(), course.toFloat()))
+                val position = Position(longitude.value.toFloat(), latitude.value.toFloat(), altitude.value.toFloat())
+                GpsValue(hdop.toFloat(), position, Velocity(speed.value.toFloat(), course.value.toFloat()))
             } else {
                 null
             }

--- a/projects/gps/build.gradle.kts
+++ b/projects/gps/build.gradle.kts
@@ -16,6 +16,7 @@ apply {
 
 dependencies {
     compile(kotlinModule("stdlib"))
+    compile(project(":units"))
     testCompile("junit:junit:4.12")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
 }

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -9,6 +9,10 @@ import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import javax.measure.Quantity
+import javax.measure.unit.Degree
+import javax.measure.unit.Metre
+import javax.measure.unit.MetrePerSecond
 
 /**
  * A GPS device.
@@ -44,10 +48,10 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
     internal fun gga(sentence: Sentence): GpsFix {
         val time = OffsetTime.of(sentence.time(0), ZoneOffset.UTC)
         val lat = sentence.doubleOrNull(1)
-        val position = lat?.let { GpsPosition(latitude = it, longitude = sentence.double(3)) }
+        val position = lat?.let { GpsPosition(latitude = Quantity.of(decimalDegrees(it), Degree), longitude = Quantity.Companion.of(decimalDegrees(sentence.double(3)), Degree)) }
         val dOP = sentence.doubleOrNull(7)?.let { GpsDilutionOfPrecision(horizontal = it) }
-        val altitude = sentence.doubleOrNull(8)
-        return GpsFix(time, position, sentence.char(5), sentence.int(6), dOP, altitude, sentence.doubleOrNull(10))
+        val altitude = sentence.doubleOrNull(8)?.let { Quantity.of(it, Metre) }
+        return GpsFix(time, position, sentence.char(5), sentence.int(6), dOP, altitude, sentence.doubleOrNull(10)?.let { Quantity.of(it, Metre) })
     }
 
     internal fun gsa(sentence: Sentence): GpsActiveSatellites {
@@ -58,16 +62,24 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
 
     internal fun gsv(sentence: Sentence): GpsSatellitesInView {
         val channel1Id = sentence.intOrNull( 3)
-        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, sentence.intOrNull( 4), sentence.intOrNull( 5), sentence.intOrNull( 6)) }
+        val channel1Elevation = sentence.intOrNull(4)?.let { Quantity.of(it, Degree) }
+        val channel1Azimuth = sentence.intOrNull(5)?.let { Quantity.of(it, Degree) }
+        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, channel1Elevation, channel1Azimuth, sentence.intOrNull( 6)) }
 
         val channel2Id = sentence.intOrNull( 7)
-        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, sentence.intOrNull( 8), sentence.intOrNull( 9), sentence.intOrNull(10)) }
+        val channel2Elevation = sentence.intOrNull(8)?.let { Quantity.of(it, Degree) }
+        val channel2Azimuth = sentence.intOrNull(9)?.let { Quantity.of(it, Degree) }
+        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, channel2Elevation, channel2Azimuth, sentence.intOrNull(10)) }
 
         val channel3Id = sentence.intOrNull(11)
-        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, sentence.intOrNull(12), sentence.intOrNull(13), sentence.intOrNull(14)) }
+        val channel3Elevation = sentence.intOrNull(12)?.let { Quantity.of(it, Degree) }
+        val channel3Azimuth = sentence.intOrNull(13)?.let { Quantity.of(it, Degree) }
+        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, channel3Elevation, channel3Azimuth, sentence.intOrNull(14)) }
 
         val channel4Id = sentence.intOrNull(15)
-        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, sentence.intOrNull(16), sentence.intOrNull(17), sentence.intOrNull(18)) }
+        val channel4Elevation = sentence.intOrNull(16)?.let { Quantity.of(it, Degree) }
+        val channel4Azimuth = sentence.intOrNull(17)?.let { Quantity.of(it, Degree) }
+        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, channel4Elevation, channel4Azimuth, sentence.intOrNull(18)) }
 
         return GpsSatellitesInView(sentence.int(0), sentence.int(1), sentence.int(2), channel1, channel2, channel3, channel4)
     }
@@ -77,14 +89,20 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
         val time = sentence.time(0)
         val datetime = OffsetDateTime.of(date, time, ZoneOffset.UTC)
         val status = sentence.char(1) == GpsNavInfo.STATUS_VALID
-        val latitude = sentence.doubleOrNull(4)
-        val longitude = sentence.doubleOrNull(2)
-        val position = if (latitude != null && longitude != null) GpsPosition(latitude, longitude) else null
-        return GpsNavInfo(datetime, status, position, sentence.doubleOrNull(6), sentence.doubleOrNull(7), sentence.char(11))
+        val speed = sentence.doubleOrNull(6)?.let { MetrePerSecond.fromKnots(it) }
+        val trueBearing = sentence.doubleOrNull(7)?.let { Quantity.of(it, Degree) }
+        val latitude = sentence.doubleOrNull(2)
+        val longitude = sentence.doubleOrNull(4)
+        val position = if (latitude != null && longitude != null) {
+            GpsPosition(Quantity.of(decimalDegrees(longitude), Degree), Quantity.of(decimalDegrees(latitude), Degree))
+        } else {
+            null
+        }
+        return GpsNavInfo(datetime, status, position, speed, trueBearing, sentence.char(11))
     }
 
     internal fun vtg(sentence: Sentence): GpsGroundVelocity {
-        return GpsGroundVelocity(sentence.double(0), sentence.double(4), sentence.char(8))
+        return GpsGroundVelocity(Quantity.of(sentence.double(0), Degree), MetrePerSecond.fromKnots(sentence.double(4)), sentence.char(8))
     }
 
     private fun Sentence.time(index: Int): LocalTime {
@@ -114,4 +132,13 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
     private fun Sentence.double(index: Int): Double {
         return String(this.fields[index]).toDouble()
     }
+
+    /**
+     * Converts a value from `ddmm.mmmm` or `dddmm.mmmm` to decimal degrees.
+     *
+     * @param value the value in `ddmm.mmmm` or `dddmm.mmmm` format
+     * @return the value in decimal degrees
+     * @see <a href="https://en.wikipedia.org/wiki/Decimal_degrees">Wikipedia: Decimal Degrees</a>
+     */
+    private fun decimalDegrees(value: Double) = ((value / 100.0).toInt() + ((value / 100.0 - (value / 100.0).toInt()) / 0.6))
 }

--- a/projects/gps/src/main/kotlin/gps/GpsFix.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsFix.kt
@@ -1,6 +1,9 @@
 package gps
 
 import java.time.OffsetTime
+import javax.measure.Quantity
+import javax.measure.quantity.Angle
+import javax.measure.quantity.Length
 
 /**
  * An NMEA 0183 GGA sentence.
@@ -10,7 +13,7 @@ import java.time.OffsetTime
  * @property positionFixIndicator whether the device does ([GPS_FIX] or [DIFFERENTIAL_GPS_FIX]) or does not have a fix ([FIX_NOT_AVAILABLE])
  * @property satellitesUsed the number of satellites used in this position (from 0 to 14)
  * @property dilutionOfPrecision the dilution of precision
- * @property altitude antenna altitude above or below mean-sea-level in meters
+ * @property altitude antenna altitude above or below mean-sea-level
  * @property geoidalSeparation geoidal separation
  */
 data class GpsFix(
@@ -19,8 +22,8 @@ data class GpsFix(
     val positionFixIndicator: Char,
     val satellitesUsed: Int,
     val dilutionOfPrecision: GpsDilutionOfPrecision?,
-    val altitude: Double?,
-    val geoidalSeparation: Double?
+    val altitude: Quantity<Length>?,
+    val geoidalSeparation: Quantity<Length>?
 ) {
     companion object {
         const val FIX_NOT_AVAILABLE = '0'

--- a/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
@@ -1,13 +1,17 @@
 package gps
 
+import javax.measure.Quantity
+import javax.measure.quantity.Angle
+import javax.measure.quantity.Speed
+
 /**
  * An NMEA 0183 `VTG` sentence.
  *
  * @property course the measured heading
- * @property speed the measured speed in knots
+ * @property speed the measured speed
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
-data class GpsGroundVelocity(val course: Double, val speed: Double, val mode: Char) {
+data class GpsGroundVelocity(val course: Quantity<Angle>, val speed: Quantity<Speed>, val mode: Char) {
     companion object {
         const val MODE_AUTONOMOUS = 'A'
         const val MODE_DIFFERENTIAL = 'D'

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -1,6 +1,9 @@
 package gps
 
 import java.time.OffsetDateTime
+import javax.measure.Quantity
+import javax.measure.quantity.Angle
+import javax.measure.quantity.Speed
 
 /**
  * An NMEA 0183 `RMC` sentence.
@@ -8,7 +11,7 @@ import java.time.OffsetDateTime
  * @property instant the timestamp for this measurement
  * @property valid whether or not this position is valid
  * @property position the GPS position
- * @property speed the measured speed in knots
+ * @property speed the measured speed
  * @property course the measured heading
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
@@ -16,8 +19,8 @@ data class GpsNavInfo(
     val instant: OffsetDateTime,
     val valid: Boolean,
     val position: GpsPosition?,
-    val speed: Double?,
-    val course: Double?,
+    val speed: Quantity<Speed>?,
+    val course: Quantity<Angle>?,
     val mode: Char
 ) {
     companion object {

--- a/projects/gps/src/main/kotlin/gps/GpsPosition.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsPosition.kt
@@ -1,9 +1,12 @@
 package gps
 
+import javax.measure.Quantity
+import javax.measure.quantity.Angle
+
 /**
  * A GPS position value.
  *
  * @property longitude the longitude in degrees decimal minute
  * @property latitude the latitude in degrees decimal minute
  */
-data class GpsPosition(val longitude: Double, val latitude: Double)
+data class GpsPosition(val longitude: Quantity<Angle>, val latitude: Quantity<Angle>)

--- a/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
@@ -1,11 +1,14 @@
 package gps
 
+import javax.measure.Quantity
+import javax.measure.quantity.Angle
+
 /**
  * A satellite message.
  *
  * @property id the satellite ID (from 1 to 32)
- * @property elevation the elevation in degrees
- * @property azimuth the azimuth measurement in degrees
+ * @property elevation the elevation
+ * @property azimuth the azimuth measurement
  * @property signalRatio the signal-to-noise ratio in dBHz
  */
-data class GpsSatelliteMessage(val id: Int, val elevation: Int?, val azimuth: Int?, val signalRatio: Int?)
+data class GpsSatelliteMessage(val id: Int, val elevation: Quantity<Angle>?, val azimuth: Quantity<Angle>?, val signalRatio: Int?)

--- a/projects/units/README.md
+++ b/projects/units/README.md
@@ -1,0 +1,18 @@
+Units
+=====
+
+A units API written in and for [Kotlin].
+
+This project is a self-serving units API written in and for [Kotlin]. It is heavily inspired by [JSR 363] so much so
+that it strives to be a strict subset of [JSR 363], not implementing methods on the `Unit` and `Quantity` interfaces
+that are not needed by the parent project.
+
+JSR 363 References:
+
+- [JSR 363 Specification][JSR 363]
+- [JSR 363 API Javadoc](http://unitsofmeasurement.github.io/unit-api/site/apidocs/index.html)
+- [JSR 363 Reference Implementation User Guide](https://unitsofmeasurement.gitbooks.io/unit-ri-userguide/content/)
+
+  [Kotlin]:https://kotlinlang.org
+  [JSR 363]:https://docs.google.com/document/d/12KhosAFriGCczBs6gwtJJDfg_QlANT92_lhxUWO2gCY
+

--- a/projects/units/build.gradle.kts
+++ b/projects/units/build.gradle.kts
@@ -1,0 +1,27 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestLogging
+
+buildscript {
+    repositories {
+        gradleScriptKotlin()
+    }
+    dependencies {
+        classpath(kotlinModule("gradle-plugin"))
+    }
+}
+
+apply {
+    plugin("kotlin")
+}
+
+dependencies {
+    compile(kotlinModule("stdlib"))
+    testCompile("junit:junit:4.12")
+}
+
+tasks.withType<Test> {
+    testLogging(closureOf<TestLogging> {
+        showStandardStreams = true
+        events("passed", "skipped", "failed")
+    })
+}

--- a/projects/units/src/main/kotlin/javax/measure/Quantity.kt
+++ b/projects/units/src/main/kotlin/javax/measure/Quantity.kt
@@ -1,0 +1,52 @@
+package javax.measure
+
+interface Quantity<Q: Quantity<Q>> {
+    companion object {
+        fun <Q: Quantity<Q>> of(value: Double, unit: Unit<Q>): Quantity<Q> = RealQuantity(value, unit)
+
+        fun <Q: Quantity<Q>> of(value: Int, unit: Unit<Q>): Quantity<Q> = of(value.toDouble(), unit)
+
+        fun <Q: Quantity<Q>> of(value: Long, unit: Unit<Q>): Quantity<Q> = of(value.toDouble(), unit)
+    }
+
+    /**
+     * Returns the value of this `Quantity`.
+     * @return the value
+     */
+    val value: Number
+
+    /**
+     * Returns the unit of this `Quantity`.
+     * @return the unit
+     */
+    val unit: Unit<Q>
+
+    /**
+     * Returns the sum of this `Quantity` with the one specified.
+     * @param augend the `Quantity` to be added
+     * @return `this + augend`
+     */
+    fun add(augend: Quantity<Q>): Quantity<Q>
+
+    /**
+     * Returns the difference between this `Quantity` and the one specified.
+     * @param subtrahend the `Quantity` to be subtracted
+     * @return `this - that`
+     */
+    fun subtract(subtrahend: Quantity<Q>): Quantity<Q>
+
+    /**
+     * Returns the product of this `Quantity` with the `Number` value specified.
+     * @param multiplier the `Number` multiplier
+     * @return `this * multiplier`
+     */
+    fun multiply(multiplier: Number): Quantity<Q>
+
+    /**
+     * Returns the product of this `Quantity` divided by the `Number` specified.
+     * @param divisor the `Number` divisor
+     * @return `this / that`
+     */
+    fun divide(divisor: Number): Quantity<Q>
+}
+

--- a/projects/units/src/main/kotlin/javax/measure/RealQuantity.kt
+++ b/projects/units/src/main/kotlin/javax/measure/RealQuantity.kt
@@ -1,0 +1,13 @@
+package javax.measure
+
+data class RealQuantity<Q: Quantity<Q>>(override val value: Double, override val unit: Unit<Q>) : Quantity<Q> {
+    override fun add(augend: Quantity<Q>) = RealQuantity(value + augend.value.toDouble(), unit)
+
+    override fun subtract(subtrahend: Quantity<Q>): Quantity<Q> = RealQuantity(value - subtrahend.value.toDouble(), unit)
+
+    override fun multiply(multiplier: Number) = RealQuantity(value * multiplier.toDouble(), unit)
+
+    override fun divide(divisor: Number) = RealQuantity(value / divisor.toDouble(), unit)
+
+    override fun toString() = "$value$unit"
+}

--- a/projects/units/src/main/kotlin/javax/measure/Unit.kt
+++ b/projects/units/src/main/kotlin/javax/measure/Unit.kt
@@ -1,0 +1,15 @@
+package javax.measure
+
+interface Unit<Q: Quantity<Q>> {
+    /**
+     * Returns the symbol of this unit.
+     * @return the symbol of this unit
+     */
+    val symbol: String
+
+    /**
+     * Returns a string representation of this unit.
+     * @return a string representation of this unit
+     */
+    override fun toString(): String
+}

--- a/projects/units/src/main/kotlin/javax/measure/quantity/Angle.kt
+++ b/projects/units/src/main/kotlin/javax/measure/quantity/Angle.kt
@@ -1,0 +1,8 @@
+package javax.measure.quantity
+
+import javax.measure.Quantity
+
+/**
+ * @see <a href="https://en.wikipedia.org/wiki/Angle">Wikipedia: Angle</a>
+ */
+interface Angle: Quantity<Angle>

--- a/projects/units/src/main/kotlin/javax/measure/quantity/Length.kt
+++ b/projects/units/src/main/kotlin/javax/measure/quantity/Length.kt
@@ -1,0 +1,10 @@
+package javax.measure.quantity
+
+import javax.measure.Quantity
+
+/**
+ * Extent of space between two objects or places.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Length">Wikipedia: Length</a>
+ */
+interface Length: Quantity<Length>

--- a/projects/units/src/main/kotlin/javax/measure/quantity/Speed.kt
+++ b/projects/units/src/main/kotlin/javax/measure/quantity/Speed.kt
@@ -1,0 +1,10 @@
+package javax.measure.quantity
+
+import javax.measure.Quantity
+
+/**
+ * Distance traveled divided by the time.
+ *
+ * @see <a href="http://en.wikipedia.org/wiki/Speed">Wikipedia: Speed</a>
+ */
+interface Speed: Quantity<Speed>

--- a/projects/units/src/main/kotlin/javax/measure/unit/Degree.kt
+++ b/projects/units/src/main/kotlin/javax/measure/unit/Degree.kt
@@ -1,0 +1,11 @@
+package javax.measure.unit
+
+import javax.measure.Unit
+import javax.measure.quantity.Angle
+
+object Degree: Unit<Angle> {
+    override val symbol
+        get() = "°"
+
+    override fun toString() = symbol
+}

--- a/projects/units/src/main/kotlin/javax/measure/unit/Metre.kt
+++ b/projects/units/src/main/kotlin/javax/measure/unit/Metre.kt
@@ -1,0 +1,11 @@
+package javax.measure.unit
+
+import javax.measure.Unit
+import javax.measure.quantity.Length
+
+object Metre: Unit<Length> {
+    override val symbol: String
+        get() = "m"
+
+    override fun toString(): String = symbol
+}

--- a/projects/units/src/main/kotlin/javax/measure/unit/MetrePerSecond.kt
+++ b/projects/units/src/main/kotlin/javax/measure/unit/MetrePerSecond.kt
@@ -1,0 +1,14 @@
+package javax.measure.unit
+
+import javax.measure.Quantity
+import javax.measure.Unit
+import javax.measure.quantity.Speed
+
+object MetrePerSecond : Unit<Speed> {
+    override val symbol: String
+        get() = "m/s"
+
+    override fun toString() = symbol
+
+    fun fromKnots(value: Double) = Quantity.of(value * 0.514444, MetrePerSecond)
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ include "gps"
 include "jmh"
 include "log"
 include "microcontrollers"
+include "units"
 
 rootProject.name = "boat"
 rootProject.buildFileName = "build.gradle.kts"


### PR DESCRIPTION
Closes #53
Closes #54

This PR updates the representations of the GPS data to include units. Previously we were storing "unitless" numbers and specifying the types implicitly (e.g. comments and documentation) and now we are moving to `Quantity`s  with `Unit`s. This API (and the interfaces in the units subproject) are a heavily inspired subset of (read: copied from) [the JSR 363 specification](https://docs.google.com/document/d/12KhosAFriGCczBs6gwtJJDfg_QlANT92_lhxUWO2gCY).

I've migrated the position values from `ddmm.mmmm` and `dddmm.mmmm` to decimal degrees<sup>\[1\]</sup> and the speed values from knots to metres per second.

1\. Which was already completed in 604710d725bc1275defb117895121dfba989f0d9 but I've taken the opportunity to move it into the GPS subproject properly. (As a side note to a side note: I was previously of the opinion that the GPS subproject should try to represent the GPS data in an [OO](https://en.wikipedia.org/wiki/Object-oriented_programming) way that doesn't *transform* the data. I no longer feel that way and think it's fine if the GPS project does sane conversions so long as we still have access to the underlying NMEA sentence that produced a value.)