### PR TITLE
Migrate build scripts away from using GSK directly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,3 @@
-allprojects {
-    repositories {
-        gradleScriptKotlin()
-    }
-}
-
 plugins {
     base
 }

--- a/projects/cli/build.gradle.kts
+++ b/projects/cli/build.gradle.kts
@@ -1,22 +1,14 @@
-buildscript {
-    repositories {
-        gradleScriptKotlin()
-    }
-    dependencies {
-        classpath(kotlinModule("gradle-plugin"))
-    }
+repositories {
+    jcenter()
 }
 
 plugins {
     application
-}
-
-apply {
-    plugin("kotlin")
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
 }
 
 dependencies {
-    compile(kotlinModule("stdlib"))
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     compile(project(":core"))
     compile(project(":gps"))
     compile(project(":log"))

--- a/projects/core/build.gradle.kts
+++ b/projects/core/build.gradle.kts
@@ -2,30 +2,24 @@ import com.google.protobuf.gradle.ProtobufConfigurator
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
 
-buildscript {
-    repositories {
-        gradleScriptKotlin()
-    }
-    dependencies {
-        classpath(kotlinModule("gradle-plugin"))
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.1")
-    }
+repositories {
+    jcenter()
 }
 
-apply {
-    plugin("kotlin")
-    plugin("com.google.protobuf")
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
+    id("com.google.protobuf") version "0.8.1"
 }
 
 dependencies {
-    compile(kotlinModule("stdlib"))
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     compile(project(":gps"))
     compile(project(":microcontrollers"))
     compile("com.google.protobuf:protobuf-java:3.2.0")
     compile("org.tinylog:tinylog:1.1")
     compile("rxbroadcast:rxbroadcast:1.1.0")
     testCompile("junit:junit:4.12")
-    testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit")
 }
 
 tasks.withType<Test> {

--- a/projects/gps/build.gradle.kts
+++ b/projects/gps/build.gradle.kts
@@ -1,23 +1,18 @@
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
 
-buildscript {
-    repositories {
-        gradleScriptKotlin()
-    }
-    dependencies {
-        classpath(kotlinModule("gradle-plugin"))
-    }
+repositories {
+    jcenter()
 }
 
-apply {
-    plugin("kotlin")
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
 }
 
 dependencies {
-    compile(kotlinModule("stdlib"))
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     testCompile("junit:junit:4.12")
-    testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit")
 }
 
 tasks.withType<Test> {

--- a/projects/jmh/build.gradle.kts
+++ b/projects/jmh/build.gradle.kts
@@ -1,23 +1,15 @@
-buildscript {
-    repositories {
-        gradleScriptKotlin()
-    }
-    dependencies {
-        classpath(kotlinModule("gradle-plugin"))
-    }
+repositories {
+    jcenter()
 }
 
 plugins {
+    id("org.jetbrains.kotlin.jvm")  version "1.1.2"
+    id("org.jetbrains.kotlin.kapt") version "1.1.2"
     application
 }
 
-apply {
-    plugin("kotlin")
-    plugin("kotlin-kapt")
-}
-
 dependencies {
-    compile(kotlinModule("stdlib"))
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     compile(project(":core"))
     compile(project(":microcontrollers"))
     compile("org.openjdk.jmh:jmh-core:1.18")

--- a/projects/log/build.gradle.kts
+++ b/projects/log/build.gradle.kts
@@ -1,16 +1,11 @@
-buildscript {
-    repositories {
-        gradleScriptKotlin()
-    }
-    dependencies {
-        classpath(kotlinModule("gradle-plugin"))
-    }
+repositories {
+    jcenter()
 }
 
-apply {
-    plugin("kotlin")
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
 }
 
 dependencies {
-    compile(kotlinModule("stdlib"))
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
 }

--- a/projects/microcontrollers/build.gradle.kts
+++ b/projects/microcontrollers/build.gradle.kts
@@ -1,24 +1,19 @@
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
 
-buildscript {
-    repositories {
-        gradleScriptKotlin()
-    }
-    dependencies {
-        classpath(kotlinModule("gradle-plugin"))
-    }
+repositories {
+    jcenter()
 }
 
-apply {
-    plugin("kotlin")
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
 }
 
 dependencies {
-    compile(kotlinModule("stdlib"))
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     compile(project(":log"))
     testCompile("junit:junit:4.12")
-    testCompile("org.jetbrains.kotlin:kotlin-test-junit:1.0.6")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
🐘

This PR migrates the Gradle build scripts to not use Gradle Script Kotlin directly and to use the Kotlin Gradle plugins.