### PR TITLE
Update GPS data to include units, for realsies

### DIFF
--- a/projects/core/build.gradle.kts
+++ b/projects/core/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
+    compile(project(":units"))
     compile(project(":gps"))
     compile(project(":microcontrollers"))
     compile("com.google.protobuf:protobuf-java:3.2.0")

--- a/projects/core/src/main/kotlin/core/Math.kt
+++ b/projects/core/src/main/kotlin/core/Math.kt
@@ -1,5 +1,0 @@
-package core
-
-fun dd(value: Float): Float {
-    return ((value / 100f).toInt() + ((value / 100f - (value / 100f).toInt()) / 0.6f))
-}

--- a/projects/core/src/main/kotlin/core/values/GpsValue.kt
+++ b/projects/core/src/main/kotlin/core/values/GpsValue.kt
@@ -1,11 +1,11 @@
 package core.values
 
-import core.dd
 import gps.GpsFix
 import gps.GpsNavInfo
 import schemas.GpsProtobuf
 import schemas.PositionProtobuf
 import schemas.VelocityProtobuf
+import units.UnitConverter
 
 data class GpsValue(val horizontalDilutionOfPrecision: Float, val position: Position, val velocity: Velocity) {
     companion object {
@@ -24,8 +24,8 @@ data class GpsValue(val horizontalDilutionOfPrecision: Float, val position: Posi
                 && speed != null
                 && course != null
             ) {
-                val position = Position(dd(longitude.toFloat()), dd(latitude.toFloat()), altitude.toFloat())
-                GpsValue(hdop.toFloat(), position, Velocity(speed.toFloat(), course.toFloat()))
+                val position = Position(longitude, latitude, altitude)
+                GpsValue(hdop.toFloat(), position, Velocity(speed, course))
             } else {
                 null
             }
@@ -36,12 +36,12 @@ data class GpsValue(val horizontalDilutionOfPrecision: Float, val position: Posi
         return GpsProtobuf.Gps.newBuilder()
             .setHorizontalDilutionOfPrecision(horizontalDilutionOfPrecision)
             .setPosition(PositionProtobuf.Position.newBuilder()
-                .setElevation(position.elevation.toDouble())
-                .setLongitude(position.longitude.toDouble())
-                .setLatitude(position.latitude.toDouble()))
+                .setElevation(UnitConverter.fromMilli(position.elevation.value))
+                .setLongitude(UnitConverter.fromNano(position.longitude.value))
+                .setLatitude(UnitConverter.fromNano(position.latitude.value)))
             .setVelocity(VelocityProtobuf.Velocity.newBuilder()
-                .setSpeed(velocity.speed.toDouble())
-                .setTrueBearing(velocity.trueBearing.toDouble()))
+                .setSpeed(UnitConverter.fromMilli(velocity.speed.value))
+                .setTrueBearing(UnitConverter.fromNano(velocity.trueBearing.value)))
             .build()
             .toByteArray()
     }

--- a/projects/core/src/main/kotlin/core/values/Position.kt
+++ b/projects/core/src/main/kotlin/core/values/Position.kt
@@ -1,3 +1,9 @@
 package core.values
 
-data class Position(val longitude: Float, val latitude: Float, val elevation: Float)
+import units.Angle
+import units.Length
+import units.Millimetre
+import units.Nanodegree
+import units.Quantity
+
+data class Position(val longitude: Quantity<Angle, Nanodegree>, val latitude: Quantity<Angle, Nanodegree>, val elevation: Quantity<Length, Millimetre>)

--- a/projects/core/src/main/kotlin/core/values/Velocity.kt
+++ b/projects/core/src/main/kotlin/core/values/Velocity.kt
@@ -1,3 +1,9 @@
 package core.values
 
-data class Velocity(val speed: Float, val trueBearing: Float)
+import units.Angle
+import units.Milliknot
+import units.Nanodegree
+import units.Quantity
+import units.Speed
+
+data class Velocity(val speed: Quantity<Speed, Milliknot>, val trueBearing: Quantity<Angle, Nanodegree>)

--- a/projects/gps/build.gradle.kts
+++ b/projects/gps/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 }
 
 dependencies {
+    compile(project(":units"))
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     testCompile("junit:junit:4.12")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit")

--- a/projects/gps/src/main/kotlin/gps/GpsFix.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsFix.kt
@@ -1,5 +1,8 @@
 package gps
 
+import units.Length
+import units.Millimetre
+import units.Quantity
 import java.time.OffsetTime
 
 /**
@@ -10,7 +13,7 @@ import java.time.OffsetTime
  * @property positionFixIndicator whether the device does ([GPS_FIX] or [DIFFERENTIAL_GPS_FIX]) or does not have a fix ([FIX_NOT_AVAILABLE])
  * @property satellitesUsed the number of satellites used in this position (from 0 to 14)
  * @property dilutionOfPrecision the dilution of precision
- * @property altitude antenna altitude above or below mean-sea-level in meters
+ * @property altitude antenna altitude above or below mean-sea-level
  * @property geoidalSeparation geoidal separation
  */
 data class GpsFix(
@@ -19,8 +22,8 @@ data class GpsFix(
     val positionFixIndicator: Char,
     val satellitesUsed: Int,
     val dilutionOfPrecision: GpsDilutionOfPrecision?,
-    val altitude: Double?,
-    val geoidalSeparation: Double?
+    val altitude: Quantity<Length, Millimetre>?,
+    val geoidalSeparation: Quantity<Length, Millimetre>?
 ) {
     companion object {
         const val FIX_NOT_AVAILABLE = '0'

--- a/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
@@ -1,13 +1,19 @@
 package gps
 
+import units.Angle
+import units.Milliknot
+import units.Nanodegree
+import units.Quantity
+import units.Speed
+
 /**
  * An NMEA 0183 `VTG` sentence.
  *
  * @property course the measured heading
- * @property speed the measured speed in knots
+ * @property speed the measured speed
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
-data class GpsGroundVelocity(val course: Double, val speed: Double, val mode: Char) {
+data class GpsGroundVelocity(val course: Quantity<Angle, Nanodegree>, val speed: Quantity<Speed, Milliknot>, val mode: Char) {
     companion object {
         const val MODE_AUTONOMOUS = 'A'
         const val MODE_DIFFERENTIAL = 'D'

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -1,5 +1,10 @@
 package gps
 
+import units.Angle
+import units.Milliknot
+import units.Nanodegree
+import units.Quantity
+import units.Speed
 import java.time.OffsetDateTime
 
 /**
@@ -8,7 +13,7 @@ import java.time.OffsetDateTime
  * @property instant the timestamp for this measurement
  * @property valid whether or not this position is valid
  * @property position the GPS position
- * @property speed the measured speed in knots
+ * @property speed the measured speed
  * @property course the measured heading
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
@@ -16,8 +21,8 @@ data class GpsNavInfo(
     val instant: OffsetDateTime,
     val valid: Boolean,
     val position: GpsPosition?,
-    val speed: Double?,
-    val course: Double?,
+    val speed: Quantity<Speed, Milliknot>?,
+    val course: Quantity<Angle, Nanodegree>?,
     val mode: Char
 ) {
     companion object {

--- a/projects/gps/src/main/kotlin/gps/GpsPosition.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsPosition.kt
@@ -1,9 +1,13 @@
 package gps
 
+import units.Angle
+import units.Nanodegree
+import units.Quantity
+
 /**
  * A GPS position value.
  *
- * @property longitude the longitude in degrees decimal minute
- * @property latitude the latitude in degrees decimal minute
+ * @property longitude the longitude
+ * @property latitude the latitude
  */
-data class GpsPosition(val longitude: Double, val latitude: Double)
+data class GpsPosition(val longitude: Quantity<Angle, Nanodegree>, val latitude: Quantity<Angle, Nanodegree>)

--- a/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
@@ -1,11 +1,15 @@
 package gps
 
+import units.Angle
+import units.Nanodegree
+import units.Quantity
+
 /**
  * A satellite message.
  *
  * @property id the satellite ID (from 1 to 32)
- * @property elevation the elevation in degrees
- * @property azimuth the azimuth measurement in degrees
+ * @property elevation the elevation
+ * @property azimuth the azimuth
  * @property signalRatio the signal-to-noise ratio in dBHz
  */
-data class GpsSatelliteMessage(val id: Int, val elevation: Int?, val azimuth: Int?, val signalRatio: Int?)
+data class GpsSatelliteMessage(val id: Int, val elevation: Quantity<Angle, Nanodegree>?, val azimuth: Quantity<Angle, Nanodegree>?, val signalRatio: Int?)

--- a/projects/units/build.gradle.kts
+++ b/projects/units/build.gradle.kts
@@ -1,0 +1,24 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestLogging
+
+repositories {
+    jcenter()
+}
+
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
+}
+
+dependencies {
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
+    compile(project(":log"))
+    testCompile("junit:junit:4.12")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit")
+}
+
+tasks.withType<Test> {
+    testLogging(closureOf<TestLogging> {
+        showStandardStreams = true
+        events("passed", "skipped", "failed")
+    })
+}

--- a/projects/units/src/main/kotlin/units/Quantity.kt
+++ b/projects/units/src/main/kotlin/units/Quantity.kt
@@ -1,0 +1,13 @@
+package units
+
+import units.UnitConverter.convert
+
+data class Quantity<T : Unit<T>, U : Unit<T>>(val value: Long, private val unit: U) {
+    constructor(value: Int, unit: U): this(value.toLong(), unit)
+
+    constructor(value: Double, unit: U): this(value.toLong(), unit)
+
+    operator fun <O: Unit<T>> plus(o: Quantity<T, O>) = Quantity(value + convert(o.value, o.unit, unit), unit)
+
+    override fun toString() = "$value$unit"
+}

--- a/projects/units/src/main/kotlin/units/Unit.kt
+++ b/projects/units/src/main/kotlin/units/Unit.kt
@@ -1,0 +1,17 @@
+package units
+
+sealed class Unit<U: Unit<U>>(val symbol: String) {
+    override fun toString() = symbol
+}
+
+sealed class Angle(symbol: String): Unit<Angle>(symbol)
+object Nanodegree: Angle("⋅10e-9°")
+
+sealed class Frequency(symbol: String): Unit<Frequency>(symbol)
+object Hertz: Frequency("Hz")
+
+sealed class Length(symbol: String): Unit<Length>(symbol)
+object Millimetre: Length("mm")
+
+sealed class Speed(symbol: String): Unit<Speed>(symbol)
+object Milliknot: Speed("⋅10e−3kn")

--- a/projects/units/src/main/kotlin/units/UnitConverter.kt
+++ b/projects/units/src/main/kotlin/units/UnitConverter.kt
@@ -1,6 +1,6 @@
 package units
 
-internal object UnitConverter {
+object UnitConverter {
     fun <T: Unit<T>> convert(value: Long, fromUnit: Unit<T>, toUnit: Unit<T>) = when (fromUnit) {
         is Angle     -> convertUnits(value, fromUnit, toUnit as Angle    )
         is Frequency -> convertUnits(value, fromUnit, toUnit as Frequency)
@@ -31,4 +31,7 @@ internal object UnitConverter {
             Milliknot -> value
         }
     }
+
+    fun fromMilli(value: Long) = value * 10e-3
+    fun fromNano(value: Long) = value * 10e-9
 }

--- a/projects/units/src/main/kotlin/units/UnitConverter.kt
+++ b/projects/units/src/main/kotlin/units/UnitConverter.kt
@@ -1,0 +1,34 @@
+package units
+
+internal object UnitConverter {
+    fun <T: Unit<T>> convert(value: Long, fromUnit: Unit<T>, toUnit: Unit<T>) = when (fromUnit) {
+        is Angle     -> convertUnits(value, fromUnit, toUnit as Angle    )
+        is Frequency -> convertUnits(value, fromUnit, toUnit as Frequency)
+        is Length    -> convertUnits(value, fromUnit, toUnit as Length   )
+        is Speed     -> convertUnits(value, fromUnit, toUnit as Speed    )
+    }
+
+    fun convertUnits(value: Long, from: Angle, to: Angle) = when (from) {
+        Nanodegree -> when (to) {
+            Nanodegree -> (value)
+        }
+    }
+
+    fun convertUnits(value: Long, from: Frequency, to: Frequency) = when (from) {
+        Hertz -> when (to) {
+            Hertz -> value
+        }
+    }
+
+    fun convertUnits(value: Long, from: Length, to: Length) = when (from) {
+        Millimetre -> when (to) {
+            Millimetre -> (value)
+        }
+    }
+
+    fun convertUnits(value: Long, from: Speed, to: Speed) = when (from) {
+        Milliknot -> when (to) {
+            Milliknot -> value
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ include "gps"
 include "jmh"
 include "log"
 include "microcontrollers"
+include "units"
 
 rootProject.name = "boat"
 rootProject.buildFileName = "build.gradle.kts"


### PR DESCRIPTION
Closes #73 (this PR supersedes that one)
Closes #53\*
Closes #54†

This PR updates the representations of the GPS data to include units. Previously we were storing "unitless" numbers and specifying the types implicitly (e.g. comments and documentation) and now we are moving to `Quantity`s  with `Unit`s. This API (similar to #73) is heavily inspired by [the JSR 363 specification](https://docs.google.com/document/d/12KhosAFriGCczBs6gwtJJDfg_QlANT92_lhxUWO2gCY) but I've tried my darnedest to have an API that can be checked at compile time which unfortunately requires a slightly different API. I think it would be possible to expose a `javax.measure` wrapper for the types introduced here.

## The API

The two main types in the API are `Unit` and `Quantity` (again, similar to JSR 363). `Unit` represents a hierarchy of units. `Quantity` represents a pairing of a value with an unit. In an attempt to around working with floating point numbers and having to deal with what resolution any particular value should need, the `Quantity` implementation stores a 64-bit signed integer and the concept of resolution is encoded in the units themselves.

For example:

```kotlin
val oneMillimetre = Quantity(1, Millimetre)
val oneMetre = Quantity(1000, Millimetre)
val oneDegree = Quantity(1e9, Nanodegree)
```

Store milli- and nano-prefixed units really doesn't have an impact on the possible range of values in a 64-bit integer. (I've added a nanodegree because I wanted to allow for as much precision in longitude and latitudes as possible.<sup>[\[2\]][2]</sup>)

## Possible concerns

While addition (and, as other overloads are added, division, multiplication, etc.) can be checked at compile-time to confirm that the units are of the same "group" (e.g. lengths, angles), conversions that introduce decimals will result in unchecked truncation.

For example, if there were a `Metre` unit:

```kotlin
val oneMetre = Quanitity(1, Metre)
val oneMillimetre = Quanitity(1, Millimetre)
oneMetre + oneMillimetre // => 1 metre
```

---

\* I've migrated the position values from `dddmm.mmmm` and `ddmm.mmmm` to decimal degrees<sup>\[1\]</sup>.

† While this PR doesn't actually convert the speeds in the GPS data into m/s, this does attach units to the values. My original issue with using knots was that without some indication of what unit the value is in that one would (rightfully) assume SI's m/s.

1\. Which was already completed in 604710d725bc1275defb117895121dfba989f0d9 but I've taken the opportunity to move it into the GPS subproject properly. (As a side note to a side note: I was previously of the opinion that the GPS subproject should try to represent the GPS data in an [OO](https://en.wikipedia.org/wiki/Object-oriented_programming) way that doesn't *transform* the data. I no longer feel that way and think it's fine if the GPS project does sane conversions so long as we still have access to the underlying NMEA sentence that produced a value.).

  [2]:https://gis.stackexchange.com/a/8674