### PR TITLE
Wrap Broadcast interface with our own type

### DIFF
--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -4,6 +4,7 @@ package cli
 
 import com.google.protobuf.InvalidProtocolBufferException
 import core.Boat
+import core.broadcast.Broadcast
 import core.hardware.ScrewPropeller
 import core.values.GpsValue
 import core.values.Motion
@@ -34,7 +35,7 @@ fun main(args: Array<String>) {
         return
     }
 
-    val broadcast = InMemoryBroadcast()
+    val broadcast = Broadcast(InMemoryBroadcast())
 
     val wSerialPort = SerialPort(args[0], baudRate = 57600)
     val pSerialPort = SerialPort(args[1], baudRate = 57600)
@@ -60,7 +61,7 @@ fun main(args: Array<String>) {
             }
         }
 
-    broadcast.valuesOfType(GpsValue::class.java)
+    broadcast.valuesOfType<GpsValue>()
         .observeOn(Schedulers.io())
         .subscribe {
             Log.d {"Sending ${it.encode().size} bytes across the wire"}

--- a/projects/core/src/main/kotlin/core/Boat.kt
+++ b/projects/core/src/main/kotlin/core/Boat.kt
@@ -1,5 +1,6 @@
 package core
 
+import core.broadcast.Broadcast
 import core.hardware.Propeller
 import core.values.GpsValue
 import core.values.Motion
@@ -11,7 +12,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import rx.Observable
 import rx.Scheduler
-import rx.broadcast.Broadcast
 import rx.subjects.PublishSubject
 import rx.subjects.Subject
 
@@ -23,14 +23,14 @@ class Boat(private val broadcast: Broadcast, private val props: Pair<Propeller, 
     private val killSwitch: Subject<Void, Void> = PublishSubject.create()
 
     fun start(io: Scheduler, clock: Scheduler) {
-        val speeds = broadcast.valuesOfType(Motion::class.java)
+        val speeds = broadcast.valuesOfType<Motion>()
             .startWith(Motion(0.0, 0.0))
             .map { speed(it) }
             .onBackpressureLatest()
         val ticks = Observable.interval(SLEEP_DURATION_MS, TimeUnit.MILLISECONDS, clock)
         val positions = Observable.combineLatest(
-            broadcast.valuesOfType(GpsFix::class.java),
-            broadcast.valuesOfType(GpsNavInfo::class.java),
+            broadcast.valuesOfType<GpsFix>(),
+            broadcast.valuesOfType<GpsNavInfo>(),
             { fix, nav -> Pair(fix, nav)}
         )
 

--- a/projects/core/src/main/kotlin/core/broadcast/Broadcast.kt
+++ b/projects/core/src/main/kotlin/core/broadcast/Broadcast.kt
@@ -1,0 +1,8 @@
+package core.broadcast
+
+import rx.Observable
+import rx.broadcast.Broadcast
+
+class Broadcast(private val broadcast: Broadcast): Broadcast by broadcast {
+    inline fun <reified T : Any> valuesOfType(): Observable<T> = valuesOfType(T::class.java)
+}

--- a/projects/core/src/test/kotlin/core/BoatTest.kt
+++ b/projects/core/src/test/kotlin/core/BoatTest.kt
@@ -1,5 +1,6 @@
 package core
 
+import core.broadcast.Broadcast
 import core.hardware.Propeller
 import core.values.Motion
 
@@ -23,7 +24,7 @@ class BoatTest {
         val broadcast = InMemoryBroadcast()
         val scheduler = TestScheduler()
         val props = Pair(NullPropeller(), NullPropeller())
-        val boat = Boat(broadcast, props)
+        val boat = Boat(Broadcast(broadcast), props)
 
         boat.start(io = scheduler, clock = scheduler)
 
@@ -47,7 +48,7 @@ class BoatTest {
         val broadcast = InMemoryBroadcast()
         val scheduler = TestScheduler()
         val props = Pair(NullPropeller(), NullPropeller())
-        val boat = Boat(broadcast, props)
+        val boat = Boat(Broadcast(broadcast), props)
 
         boat.start(io = scheduler, clock = scheduler)
 
@@ -71,7 +72,7 @@ class BoatTest {
         val broadcast = InMemoryBroadcast()
         val scheduler = TestScheduler()
         val props = Pair(NullPropeller(), NullPropeller())
-        val boat = Boat(broadcast, props)
+        val boat = Boat(Broadcast(broadcast), props)
 
         boat.start(io = scheduler, clock = scheduler)
 

--- a/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
+++ b/projects/jmh/src/main/kotlin/jmh/BoatBenchmark.kt
@@ -1,6 +1,7 @@
 package jmh
 
 import core.Boat
+import core.broadcast.Broadcast
 import core.hardware.Propeller
 import core.hardware.ScrewPropeller
 import core.values.Motion
@@ -39,7 +40,7 @@ open class BoatBenchmark {
 
     @Benchmark
     fun tick(): Pair<NullPropeller, NullPropeller> {
-        val broadcast = InMemoryBroadcast()
+        val broadcast = Broadcast(InMemoryBroadcast())
         val scheduler = TestScheduler()
         val props = Pair(NullPropeller(), NullPropeller())
         val boat = Boat(broadcast, props)
@@ -105,7 +106,7 @@ open class BoatBenchmark {
 
         val boatClockScheduler = TestScheduler()
         val wirelessClockScheduler = TestScheduler()
-        val broadcast = InMemoryBroadcast()
+        val broadcast = Broadcast(InMemoryBroadcast())
         val boat = Boat(broadcast, props)
 
         boat.start(io = Schedulers.io(), clock = boatClockScheduler)


### PR DESCRIPTION
Refs RxBroadcast/RxBroadcast#59

This PR adds a wrapper class around RxBroadcast's `Broadcast` interface to offer methods with a bit more of that tasty Kotlin sugar. If and when something like this is in RxBroadcast core, we can replace this with whatever the 1st-party version is.