### PR TITLE
Update Gradle build to set JVM options for Kotlin

### DIFF
--- a/projects/core/build.gradle.kts
+++ b/projects/core/build.gradle.kts
@@ -3,6 +3,8 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+project.extensions.add("protobuf", ProtobufConfigurator(project, null))
+
 repositories {
     jcenter()
 }
@@ -32,12 +34,12 @@ tasks.withType<Test> {
 }
 
 tasks.withType<KotlinCompile> {
+    dependsOn.add("generateProto")
     kotlinOptions {
         jvmTarget = "1.8"
     }
 }
 
-val protobuf = ProtobufConfigurator(project, null)
-protobuf.generatedFilesBaseDir = "${projectDir}/src"
-project.extensions.add("protobuf", protobuf)
-tasks.get("compileKotlin").dependsOn("generateProto")
+configure<ProtobufConfigurator> {
+    generatedFilesBaseDir = "$projectDir/src"
+}

--- a/projects/core/build.gradle.kts
+++ b/projects/core/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.google.protobuf.gradle.ProtobufConfigurator
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 repositories {
     jcenter()
@@ -28,6 +29,12 @@ tasks.withType<Test> {
         showStandardStreams = true
         events("passed", "skipped", "failed")
     })
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 val protobuf = ProtobufConfigurator(project, null)


### PR DESCRIPTION
🐘

This PR updates the Gradle build to set the JVM options for Kotlin in core.

(I've also tried to clean up the protbuf configuration.)