### PR TITLE
Update GPS data to include units, 🎬

### DIFF
--- a/projects/core/build.gradle.kts
+++ b/projects/core/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
+    compile(project(":units"))
     compile(project(":gps"))
     compile(project(":microcontrollers"))
     compile("com.google.protobuf:protobuf-java:3.2.0")

--- a/projects/core/src/main/kotlin/core/Math.kt
+++ b/projects/core/src/main/kotlin/core/Math.kt
@@ -1,5 +1,0 @@
-package core
-
-fun dd(value: Float): Float {
-    return ((value / 100f).toInt() + ((value / 100f - (value / 100f).toInt()) / 0.6f))
-}

--- a/projects/core/src/main/kotlin/core/values/GpsValue.kt
+++ b/projects/core/src/main/kotlin/core/values/GpsValue.kt
@@ -1,6 +1,5 @@
 package core.values
 
-import core.dd
 import gps.GpsFix
 import gps.GpsNavInfo
 import schemas.GpsProtobuf
@@ -24,8 +23,8 @@ data class GpsValue(val horizontalDilutionOfPrecision: Float, val position: Posi
                 && speed != null
                 && course != null
             ) {
-                val position = Position(dd(longitude.toFloat()), dd(latitude.toFloat()), altitude.toFloat())
-                GpsValue(hdop.toFloat(), position, Velocity(speed.toFloat(), course.toFloat()))
+                val position = Position(longitude, latitude, altitude)
+                GpsValue(hdop.toFloat(), position, Velocity(speed, course))
             } else {
                 null
             }
@@ -36,12 +35,12 @@ data class GpsValue(val horizontalDilutionOfPrecision: Float, val position: Posi
         return GpsProtobuf.Gps.newBuilder()
             .setHorizontalDilutionOfPrecision(horizontalDilutionOfPrecision)
             .setPosition(PositionProtobuf.Position.newBuilder()
-                .setElevation(position.elevation.toDouble())
-                .setLongitude(position.longitude.toDouble())
-                .setLatitude(position.latitude.toDouble()))
+                .setElevation(position.elevation.value)
+                .setLongitude(position.longitude.value)
+                .setLatitude(position.latitude.value))
             .setVelocity(VelocityProtobuf.Velocity.newBuilder()
-                .setSpeed(velocity.speed.toDouble())
-                .setTrueBearing(velocity.trueBearing.toDouble()))
+                .setSpeed(velocity.speed.value)
+                .setTrueBearing(velocity.trueBearing.value))
             .build()
             .toByteArray()
     }

--- a/projects/core/src/main/kotlin/core/values/Position.kt
+++ b/projects/core/src/main/kotlin/core/values/Position.kt
@@ -1,3 +1,9 @@
 package core.values
 
-data class Position(val longitude: Float, val latitude: Float, val elevation: Float)
+import units.Angle
+import units.Length
+import units.Metre
+import units.Degree
+import units.Quantity
+
+data class Position(val longitude: Quantity<Angle, Degree>, val latitude: Quantity<Angle, Degree>, val elevation: Quantity<Length, Metre>)

--- a/projects/core/src/main/kotlin/core/values/Velocity.kt
+++ b/projects/core/src/main/kotlin/core/values/Velocity.kt
@@ -1,9 +1,9 @@
 package core.values
 
 import units.Angle
-import units.Knot
 import units.Degree
+import units.MetrePerSecond
 import units.Quantity
 import units.Speed
 
-data class Velocity(val speed: Quantity<Speed, Knot>, val trueBearing: Quantity<Angle, Degree>)
+data class Velocity(val speed: Quantity<Speed, MetrePerSecond>, val trueBearing: Quantity<Angle, Degree>)

--- a/projects/core/src/main/kotlin/core/values/Velocity.kt
+++ b/projects/core/src/main/kotlin/core/values/Velocity.kt
@@ -1,3 +1,9 @@
 package core.values
 
-data class Velocity(val speed: Float, val trueBearing: Float)
+import units.Angle
+import units.Knot
+import units.Degree
+import units.Quantity
+import units.Speed
+
+data class Velocity(val speed: Quantity<Speed, Knot>, val trueBearing: Quantity<Angle, Degree>)

--- a/projects/gps/build.gradle.kts
+++ b/projects/gps/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 }
 
 dependencies {
+    compile(project(":units"))
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
     testCompile("junit:junit:4.12")
     testCompile("org.jetbrains.kotlin:kotlin-test-junit")

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -2,6 +2,7 @@ package gps
 
 import gps.parser.Sentence
 import gps.parser.SentenceParser
+import units.Decibel
 import units.Degree
 import units.Knot
 import units.Knot.convert
@@ -67,22 +68,26 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
         val channel1Id = sentence.intOrNull(3)
         val channel1Elevation = sentence.doubleOrNull(4)?.let { Quantity(it, Degree) }
         val channel1Azimuth = sentence.doubleOrNull(5)?.let { Quantity(it, Degree) }
-        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, channel1Elevation, channel1Azimuth, sentence.intOrNull( 6)) }
+        val channel1SignalNoiseRatio = sentence.intOrNull(6)?.let { Quantity(it, Decibel) }
+        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, channel1Elevation, channel1Azimuth, channel1SignalNoiseRatio) }
 
         val channel2Id = sentence.intOrNull(7)
         val channel2Elevation = sentence.doubleOrNull(8)?.let { Quantity(it, Degree) }
         val channel2Azimuth = sentence.doubleOrNull(9)?.let { Quantity(it, Degree) }
-        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, channel2Elevation, channel2Azimuth, sentence.intOrNull(10)) }
+        val channel2SignalNoiseRatio = sentence.intOrNull(10)?.let { Quantity(it, Decibel) }
+        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, channel2Elevation, channel2Azimuth, channel2SignalNoiseRatio) }
 
         val channel3Id = sentence.intOrNull(11)
         val channel3Elevation = sentence.doubleOrNull(12)?.let { Quantity(it, Degree) }
         val channel3Azimuth = sentence.doubleOrNull(13)?.let { Quantity(it, Degree) }
-        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, channel3Elevation, channel3Azimuth, sentence.intOrNull(14)) }
+        val channel3SignalNoiseRatio = sentence.intOrNull(14)?.let { Quantity(it, Decibel) }
+        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, channel3Elevation, channel3Azimuth, channel3SignalNoiseRatio) }
 
         val channel4Id = sentence.intOrNull(15)
         val channel4Elevation = sentence.doubleOrNull(16)?.let { Quantity(it, Degree) }
         val channel4Azimuth = sentence.doubleOrNull(17)?.let { Quantity(it, Degree) }
-        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, channel4Elevation, channel4Azimuth, sentence.intOrNull(18)) }
+        val channel4SignalNoiseRatio = sentence.intOrNull(18)?.let { Quantity(it, Decibel) }
+        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, channel4Elevation, channel4Azimuth, channel4SignalNoiseRatio) }
 
         return GpsSatellitesInView(sentence.int(0), sentence.int(1), sentence.int(2), channel1, channel2, channel3, channel4)
     }

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -4,7 +4,9 @@ import gps.parser.Sentence
 import gps.parser.SentenceParser
 import units.Degree
 import units.Knot
+import units.Knot.convert
 import units.Metre
+import units.MetrePerSecond
 import units.Quantity
 
 import java.time.LocalDate
@@ -93,13 +95,14 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
         val latitude = sentence.decimalDegreesOrNull(4, 5)
         val longitude = sentence.decimalDegreesOrNull(2, 3)
         val position = if (latitude != null && longitude != null) GpsPosition(latitude, longitude) else null
-        val speed = sentence.doubleOrNull(6)?.let { Quantity(it, Knot) }
+        val speed = sentence.doubleOrNull(6)?.let { Quantity(it, Knot).convert<MetrePerSecond>(MetrePerSecond) }
         val course = sentence.doubleOrNull(7)?.let { Quantity(it, Degree) }
+
         return GpsNavInfo(datetime, status, position, speed, course, sentence.char(11))
     }
 
     internal fun vtg(sentence: Sentence): GpsGroundVelocity {
-        return GpsGroundVelocity(Quantity(sentence.double(0), Degree), Quantity(sentence.double(4), Knot), sentence.char(8))
+        return GpsGroundVelocity(Quantity(sentence.double(0), Degree), Quantity(sentence.double(4), Knot).convert(MetrePerSecond), sentence.char(8))
     }
 
     private fun Sentence.time(index: Int): LocalTime {

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -2,6 +2,10 @@ package gps
 
 import gps.parser.Sentence
 import gps.parser.SentenceParser
+import units.Degree
+import units.Knot
+import units.Metre
+import units.Quantity
 
 import java.time.LocalDate
 import java.time.LocalTime
@@ -43,11 +47,12 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
 
     internal fun gga(sentence: Sentence): GpsFix {
         val time = OffsetTime.of(sentence.time(0), ZoneOffset.UTC)
-        val lat = sentence.doubleOrNull(1)
-        val position = lat?.let { GpsPosition(latitude = it, longitude = sentence.double(3)) }
+        val lat = sentence.decimalDegreesOrNull(1, 2)
+        val position = lat?.let { GpsPosition(latitude = it, longitude = sentence.decimalDegreesOrNull(3, 4)!!) }
         val dOP = sentence.doubleOrNull(7)?.let { GpsDilutionOfPrecision(horizontal = it) }
-        val altitude = sentence.doubleOrNull(8)
-        return GpsFix(time, position, sentence.char(5), sentence.int(6), dOP, altitude, sentence.doubleOrNull(10))
+        val altitude = sentence.doubleOrNull(8)?.let { Quantity(it, Metre) }
+        val geoidalSeparation = sentence.doubleOrNull(10)?.let { Quantity(it, Metre) }
+        return GpsFix(time, position, sentence.char(5), sentence.int(6), dOP, altitude, geoidalSeparation)
     }
 
     internal fun gsa(sentence: Sentence): GpsActiveSatellites {
@@ -57,17 +62,25 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
     }
 
     internal fun gsv(sentence: Sentence): GpsSatellitesInView {
-        val channel1Id = sentence.intOrNull( 3)
-        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, sentence.intOrNull( 4), sentence.intOrNull( 5), sentence.intOrNull( 6)) }
+        val channel1Id = sentence.intOrNull(3)
+        val channel1Elevation = sentence.doubleOrNull(4)?.let { Quantity(it, Degree) }
+        val channel1Azimuth = sentence.doubleOrNull(5)?.let { Quantity(it, Degree) }
+        val channel1 = channel1Id?.let { GpsSatelliteMessage(it, channel1Elevation, channel1Azimuth, sentence.intOrNull( 6)) }
 
-        val channel2Id = sentence.intOrNull( 7)
-        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, sentence.intOrNull( 8), sentence.intOrNull( 9), sentence.intOrNull(10)) }
+        val channel2Id = sentence.intOrNull(7)
+        val channel2Elevation = sentence.doubleOrNull(8)?.let { Quantity(it, Degree) }
+        val channel2Azimuth = sentence.doubleOrNull(9)?.let { Quantity(it, Degree) }
+        val channel2 = channel2Id?.let { GpsSatelliteMessage(it, channel2Elevation, channel2Azimuth, sentence.intOrNull(10)) }
 
         val channel3Id = sentence.intOrNull(11)
-        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, sentence.intOrNull(12), sentence.intOrNull(13), sentence.intOrNull(14)) }
+        val channel3Elevation = sentence.doubleOrNull(12)?.let { Quantity(it, Degree) }
+        val channel3Azimuth = sentence.doubleOrNull(13)?.let { Quantity(it, Degree) }
+        val channel3 = channel3Id?.let { GpsSatelliteMessage(it, channel3Elevation, channel3Azimuth, sentence.intOrNull(14)) }
 
         val channel4Id = sentence.intOrNull(15)
-        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, sentence.intOrNull(16), sentence.intOrNull(17), sentence.intOrNull(18)) }
+        val channel4Elevation = sentence.doubleOrNull(16)?.let { Quantity(it, Degree) }
+        val channel4Azimuth = sentence.doubleOrNull(17)?.let { Quantity(it, Degree) }
+        val channel4 = channel4Id?.let { GpsSatelliteMessage(it, channel4Elevation, channel4Azimuth, sentence.intOrNull(18)) }
 
         return GpsSatellitesInView(sentence.int(0), sentence.int(1), sentence.int(2), channel1, channel2, channel3, channel4)
     }
@@ -77,14 +90,16 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
         val time = sentence.time(0)
         val datetime = OffsetDateTime.of(date, time, ZoneOffset.UTC)
         val status = sentence.char(1) == GpsNavInfo.STATUS_VALID
-        val latitude = sentence.doubleOrNull(4)
-        val longitude = sentence.doubleOrNull(2)
+        val latitude = sentence.decimalDegreesOrNull(4, 5)
+        val longitude = sentence.decimalDegreesOrNull(2, 3)
         val position = if (latitude != null && longitude != null) GpsPosition(latitude, longitude) else null
-        return GpsNavInfo(datetime, status, position, sentence.doubleOrNull(6), sentence.doubleOrNull(7), sentence.char(11))
+        val speed = sentence.doubleOrNull(6)?.let { Quantity(it, Knot) }
+        val course = sentence.doubleOrNull(7)?.let { Quantity(it, Degree) }
+        return GpsNavInfo(datetime, status, position, speed, course, sentence.char(11))
     }
 
     internal fun vtg(sentence: Sentence): GpsGroundVelocity {
-        return GpsGroundVelocity(sentence.double(0), sentence.double(4), sentence.char(8))
+        return GpsGroundVelocity(Quantity(sentence.double(0), Degree), Quantity(sentence.double(4), Knot), sentence.char(8))
     }
 
     private fun Sentence.time(index: Int): LocalTime {
@@ -113,5 +128,35 @@ class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
 
     private fun Sentence.double(index: Int): Double {
         return String(this.fields[index]).toDouble()
+    }
+
+    /**
+     * Returns the sentence field at the given index in decimal degrees.
+     *
+     * Converts the field value from `ddmm.mmmm` (or `dddmm.mmmm` in the case of longitude) to decimal degrees.
+     *
+     * @param index the field index
+     * @return the value in decimal degrees
+     * @see <a href="https://en.wikipedia.org/wiki/Decimal_degrees">Wikipedia: Decimal Degrees</a>
+     */
+    private fun Sentence.decimalDegreesOrNull(index: Int, signIndex: Int) = this.fields.getOrNull(index)?.let {
+        val s = String(it)
+
+        if (s == "") {
+            return null
+        }
+
+        val indexOfDecimal = s.indexOf('.')
+        val degrees = (s.slice(0..(indexOfDecimal - 3))).toDouble()
+        val decimalMinutes = s.slice((indexOfDecimal - 2)..s.lastIndex).toDouble()
+        val decimalDegrees = (decimalMinutes / 60)
+
+        val direction = this.fields.getOrNull(signIndex)
+        val sign = when (direction?.let { String(it) }) {
+            "S", "W" -> -1L
+            else -> 1L
+        }
+
+        Quantity(sign * (degrees + decimalDegrees), Degree)
     }
 }

--- a/projects/gps/src/main/kotlin/gps/GpsFix.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsFix.kt
@@ -1,5 +1,8 @@
 package gps
 
+import units.Length
+import units.Metre
+import units.Quantity
 import java.time.OffsetTime
 
 /**
@@ -10,7 +13,7 @@ import java.time.OffsetTime
  * @property positionFixIndicator whether the device does ([GPS_FIX] or [DIFFERENTIAL_GPS_FIX]) or does not have a fix ([FIX_NOT_AVAILABLE])
  * @property satellitesUsed the number of satellites used in this position (from 0 to 14)
  * @property dilutionOfPrecision the dilution of precision
- * @property altitude antenna altitude above or below mean-sea-level in meters
+ * @property altitude antenna altitude above or below mean-sea-level
  * @property geoidalSeparation geoidal separation
  */
 data class GpsFix(
@@ -19,8 +22,8 @@ data class GpsFix(
     val positionFixIndicator: Char,
     val satellitesUsed: Int,
     val dilutionOfPrecision: GpsDilutionOfPrecision?,
-    val altitude: Double?,
-    val geoidalSeparation: Double?
+    val altitude: Quantity<Length, Metre>?,
+    val geoidalSeparation: Quantity<Length, Metre>?
 ) {
     companion object {
         const val FIX_NOT_AVAILABLE = '0'

--- a/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
@@ -1,13 +1,19 @@
 package gps
 
+import units.Angle
+import units.Knot
+import units.Degree
+import units.Quantity
+import units.Speed
+
 /**
  * An NMEA 0183 `VTG` sentence.
  *
  * @property course the measured heading
- * @property speed the measured speed in knots
+ * @property speed the measured speed
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
-data class GpsGroundVelocity(val course: Double, val speed: Double, val mode: Char) {
+data class GpsGroundVelocity(val course: Quantity<Angle, Degree>, val speed: Quantity<Speed, Knot>, val mode: Char) {
     companion object {
         const val MODE_AUTONOMOUS = 'A'
         const val MODE_DIFFERENTIAL = 'D'

--- a/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsGroundVelocity.kt
@@ -1,8 +1,8 @@
 package gps
 
 import units.Angle
-import units.Knot
 import units.Degree
+import units.MetrePerSecond
 import units.Quantity
 import units.Speed
 
@@ -13,7 +13,7 @@ import units.Speed
  * @property speed the measured speed
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
-data class GpsGroundVelocity(val course: Quantity<Angle, Degree>, val speed: Quantity<Speed, Knot>, val mode: Char) {
+data class GpsGroundVelocity(val course: Quantity<Angle, Degree>, val speed: Quantity<Speed, MetrePerSecond>, val mode: Char) {
     companion object {
         const val MODE_AUTONOMOUS = 'A'
         const val MODE_DIFFERENTIAL = 'D'

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -1,5 +1,11 @@
 package gps
 
+import units.Angle
+import units.Knot
+import units.Degree
+import units.Quantity
+import units.Speed
+
 import java.time.OffsetDateTime
 
 /**
@@ -8,7 +14,7 @@ import java.time.OffsetDateTime
  * @property instant the timestamp for this measurement
  * @property valid whether or not this position is valid
  * @property position the GPS position
- * @property speed the measured speed in knots
+ * @property speed the measured speed
  * @property course the measured heading
  * @property mode the device mode when this velocity was measured (i.e. [MODE_AUTONOMOUS], [MODE_DIFFERENTIAL], or [MODE_ESTIMATED])
  */
@@ -16,8 +22,8 @@ data class GpsNavInfo(
     val instant: OffsetDateTime,
     val valid: Boolean,
     val position: GpsPosition?,
-    val speed: Double?,
-    val course: Double?,
+    val speed: Quantity<Speed, Knot>?,
+    val course: Quantity<Angle, Degree>?,
     val mode: Char
 ) {
     companion object {

--- a/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsNavInfo.kt
@@ -1,8 +1,8 @@
 package gps
 
 import units.Angle
-import units.Knot
 import units.Degree
+import units.MetrePerSecond
 import units.Quantity
 import units.Speed
 
@@ -22,7 +22,7 @@ data class GpsNavInfo(
     val instant: OffsetDateTime,
     val valid: Boolean,
     val position: GpsPosition?,
-    val speed: Quantity<Speed, Knot>?,
+    val speed: Quantity<Speed, MetrePerSecond>?,
     val course: Quantity<Angle, Degree>?,
     val mode: Char
 ) {

--- a/projects/gps/src/main/kotlin/gps/GpsPosition.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsPosition.kt
@@ -1,9 +1,13 @@
 package gps
 
+import units.Angle
+import units.Degree
+import units.Quantity
+
 /**
  * A GPS position value.
  *
- * @property longitude the longitude in degrees decimal minute
- * @property latitude the latitude in degrees decimal minute
+ * @property longitude the longitude
+ * @property latitude the latitude
  */
-data class GpsPosition(val longitude: Double, val latitude: Double)
+data class GpsPosition(val longitude: Quantity<Angle, Degree>, val latitude: Quantity<Angle, Degree>)

--- a/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
@@ -1,8 +1,10 @@
 package gps
 
 import units.Angle
+import units.Decibel
 import units.Degree
 import units.Quantity
+import units.SignalNoiseRatio
 
 /**
  * A satellite message.
@@ -12,4 +14,4 @@ import units.Quantity
  * @property azimuth the azimuth
  * @property signalRatio the signal-to-noise ratio in dBHz
  */
-data class GpsSatelliteMessage(val id: Int, val elevation: Quantity<Angle, Degree>?, val azimuth: Quantity<Angle, Degree>?, val signalRatio: Int?)
+data class GpsSatelliteMessage(val id: Int, val elevation: Quantity<Angle, Degree>?, val azimuth: Quantity<Angle, Degree>?, val signalRatio: Quantity<SignalNoiseRatio, Decibel>?)

--- a/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
+++ b/projects/gps/src/main/kotlin/gps/GpsSatelliteMessage.kt
@@ -1,11 +1,15 @@
 package gps
 
+import units.Angle
+import units.Degree
+import units.Quantity
+
 /**
  * A satellite message.
  *
  * @property id the satellite ID (from 1 to 32)
- * @property elevation the elevation in degrees
- * @property azimuth the azimuth measurement in degrees
+ * @property elevation the elevation
+ * @property azimuth the azimuth
  * @property signalRatio the signal-to-noise ratio in dBHz
  */
-data class GpsSatelliteMessage(val id: Int, val elevation: Int?, val azimuth: Int?, val signalRatio: Int?)
+data class GpsSatelliteMessage(val id: Int, val elevation: Quantity<Angle, Degree>?, val azimuth: Quantity<Angle, Degree>?, val signalRatio: Int?)

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -7,6 +7,7 @@ import units.Quantity
 
 import org.junit.Assert
 import org.junit.Test
+import units.Decibel
 import units.MetrePerSecond
 
 import java.time.OffsetDateTime
@@ -39,10 +40,10 @@ class GpsTest {
 
     @Test
     fun testGsvSentence1() {
-        val channel1 = GpsSatelliteMessage(29, Quantity(36, Degree), Quantity( 29, Degree), 42)
-        val channel2 = GpsSatelliteMessage(21, Quantity(46, Degree), Quantity(314, Degree), 43)
-        val channel3 = GpsSatelliteMessage(26, Quantity(44, Degree), Quantity( 20, Degree), 43)
-        val channel4 = GpsSatelliteMessage(15, Quantity(21, Degree), Quantity(321, Degree), 39)
+        val channel1 = GpsSatelliteMessage(29, Quantity(36, Degree), Quantity( 29, Degree), Quantity(42, Decibel))
+        val channel2 = GpsSatelliteMessage(21, Quantity(46, Degree), Quantity(314, Degree), Quantity(43, Decibel))
+        val channel3 = GpsSatelliteMessage(26, Quantity(44, Degree), Quantity( 20, Degree), Quantity(43, Decibel))
+        val channel4 = GpsSatelliteMessage(15, Quantity(21, Degree), Quantity(321, Degree), Quantity(39, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 1, 9, channel1, channel2, channel3, channel4)
 
         val gps = Gps({ '?' }, { })
@@ -53,10 +54,10 @@ class GpsTest {
 
     @Test
     fun testGsvSentence2() {
-        val channel1 = GpsSatelliteMessage(18, Quantity(26, Degree), Quantity(314, Degree), 40)
-        val channel2 = GpsSatelliteMessage( 9, Quantity(57, Degree), Quantity(170, Degree), 44)
-        val channel3 = GpsSatelliteMessage( 6, Quantity(20, Degree), Quantity(229, Degree), 37)
-        val channel4 = GpsSatelliteMessage(10, Quantity(26, Degree), Quantity( 84, Degree), 37)
+        val channel1 = GpsSatelliteMessage(18, Quantity(26, Degree), Quantity(314, Degree), Quantity(40, Decibel))
+        val channel2 = GpsSatelliteMessage( 9, Quantity(57, Degree), Quantity(170, Degree), Quantity(44, Decibel))
+        val channel3 = GpsSatelliteMessage( 6, Quantity(20, Degree), Quantity(229, Degree), Quantity(37, Decibel))
+        val channel4 = GpsSatelliteMessage(10, Quantity(26, Degree), Quantity( 84, Degree), Quantity(37, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 2, 9, channel1, channel2, channel3, channel4)
 
         val gps = Gps({ '?' }, { })
@@ -67,7 +68,7 @@ class GpsTest {
 
     @Test
     fun testGsvSentence3() {
-        val channel1 = GpsSatelliteMessage(7, null,  null, 26)
+        val channel1 = GpsSatelliteMessage(7, null,  null, Quantity(26, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 3, 9, channel1)
 
         val gps = Gps({ '?' }, { })
@@ -157,9 +158,9 @@ class GpsTest {
     @Test
     fun testGsvSentenceMissingSomeSignalNoiseRatio() {
         val channel1 = GpsSatelliteMessage( 8, Quantity(78, Degree), Quantity(253, Degree), null)
-        val channel2 = GpsSatelliteMessage(27, Quantity(60, Degree), Quantity( 55, Degree), 21)
+        val channel2 = GpsSatelliteMessage(27, Quantity(60, Degree), Quantity( 55, Degree), Quantity(21, Decibel))
         val channel3 = GpsSatelliteMessage( 7, Quantity(56, Degree), Quantity(280, Degree), null)
-        val channel4 = GpsSatelliteMessage(16, Quantity(34, Degree), Quantity( 98, Degree), 23)
+        val channel4 = GpsSatelliteMessage(16, Quantity(34, Degree), Quantity( 98, Degree), Quantity(23, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 1, 12, channel1, channel2, channel3, channel4)
 
         val gps = Gps({ '?' }, { })

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -1,8 +1,14 @@
 package gps
 
 import gps.parser.Sentence
+import units.Degree
+import units.Knot
+import units.Metre
+import units.Quantity
+
 import org.junit.Assert
 import org.junit.Test
+
 import java.time.OffsetDateTime
 import java.time.OffsetTime
 import java.time.ZoneOffset
@@ -13,15 +19,15 @@ class GpsTest {
         val gps = Gps({ '?' }, { })
         val vtg = gps.vtg(Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A")))
 
-        Assert.assertEquals(GpsGroundVelocity(165.48, 0.03, 'A'), vtg)
+        Assert.assertEquals(GpsGroundVelocity(Quantity(165.48, Degree), Quantity(0.03, Knot), 'A'), vtg)
         Assert.assertTrue("Mode should be Autonomous", vtg.mode == GpsGroundVelocity.MODE_AUTONOMOUS)
     }
 
     @Test
     fun testRmcSentence() {
         val time = OffsetDateTime.of(2006, 4, 26, 6, 49, 51, 0, ZoneOffset.UTC)
-        val position = GpsPosition(latitude = 2307.1256, longitude = 12016.4438)
-        val expectedGpsNavInfo = GpsNavInfo(time, true, position, 0.03, 165.48, 'A')
+        val position = GpsPosition(latitude = Quantity(23.11876, Degree), longitude = Quantity(120.27406333333333, Degree))
+        val expectedGpsNavInfo = GpsNavInfo(time, true, position, Quantity(0.03, Knot), Quantity(165.48, Degree), 'A')
 
         val gps = Gps({ '?' }, { })
         val rmc = gps.rmc(Sentence("GP", "RMC", arrayOf("064951.000", "A", "2307.1256", "N", "12016.4438", "E", "0.03", "165.48", "260406", "3.05", "W", "A")))
@@ -33,10 +39,10 @@ class GpsTest {
 
     @Test
     fun testGsvSentence1() {
-        val channel1 = GpsSatelliteMessage(29, 36,  29, 42)
-        val channel2 = GpsSatelliteMessage(21, 46, 314, 43)
-        val channel3 = GpsSatelliteMessage(26, 44,  20, 43)
-        val channel4 = GpsSatelliteMessage(15, 21, 321, 39)
+        val channel1 = GpsSatelliteMessage(29, Quantity(36, Degree), Quantity( 29, Degree), 42)
+        val channel2 = GpsSatelliteMessage(21, Quantity(46, Degree), Quantity(314, Degree), 43)
+        val channel3 = GpsSatelliteMessage(26, Quantity(44, Degree), Quantity( 20, Degree), 43)
+        val channel4 = GpsSatelliteMessage(15, Quantity(21, Degree), Quantity(321, Degree), 39)
         val expectedGsv = GpsSatellitesInView(3, 1, 9, channel1, channel2, channel3, channel4)
 
         val gps = Gps({ '?' }, { })
@@ -47,10 +53,10 @@ class GpsTest {
 
     @Test
     fun testGsvSentence2() {
-        val channel1 = GpsSatelliteMessage(18, 26, 314, 40)
-        val channel2 = GpsSatelliteMessage( 9, 57, 170, 44)
-        val channel3 = GpsSatelliteMessage( 6, 20, 229, 37)
-        val channel4 = GpsSatelliteMessage(10, 26,  84, 37)
+        val channel1 = GpsSatelliteMessage(18, Quantity(26, Degree), Quantity(314, Degree), 40)
+        val channel2 = GpsSatelliteMessage( 9, Quantity(57, Degree), Quantity(170, Degree), 44)
+        val channel3 = GpsSatelliteMessage( 6, Quantity(20, Degree), Quantity(229, Degree), 37)
+        val channel4 = GpsSatelliteMessage(10, Quantity(26, Degree), Quantity( 84, Degree), 37)
         val expectedGsv = GpsSatellitesInView(3, 2, 9, channel1, channel2, channel3, channel4)
 
         val gps = Gps({ '?' }, { })
@@ -85,8 +91,8 @@ class GpsTest {
     @Test
     fun testGgaSentence() {
         val time = OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC)
-        val position = GpsPosition(latitude = 2307.1256, longitude = 12016.4438)
-        val expected = GpsFix(time, position, '1', 8, GpsDilutionOfPrecision(horizontal = 0.95), 39.9, 17.8)
+        val position = GpsPosition(latitude = Quantity(23.11876, Degree), longitude = Quantity(120.27406333333333, Degree))
+        val expected = GpsFix(time, position, '1', 8, GpsDilutionOfPrecision(horizontal = 0.95), Quantity(39.9, Metre), Quantity(17.8, Metre))
 
         val gps = Gps({ '?' }, { })
         val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "2307.1256", "N", "12016.4438", "E", "1", "8", "0.95", "39.9", "M", "17.8", "M", "", "")))
@@ -140,7 +146,7 @@ class GpsTest {
 
     @Test
     fun testGgaSentenceWithoutLock() {
-        val expected = GpsFix(OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC), null, '0', 0, null, null, 0.0)
+        val expected = GpsFix(OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC), null, '0', 0, null, null, Quantity(0, Metre))
 
         val gps = Gps({ '?' }, { })
         val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "", "", "", "", "0", "00", "", "", "M", "0.0", "M", "", "0000")))
@@ -150,10 +156,10 @@ class GpsTest {
 
     @Test
     fun testGsvSentenceMissingSomeSignalNoiseRatio() {
-        val channel1 = GpsSatelliteMessage(8, 78, 253, null)
-        val channel2 = GpsSatelliteMessage(27, 60, 55, 21)
-        val channel3 = GpsSatelliteMessage(7, 56, 280, null)
-        val channel4 = GpsSatelliteMessage(16, 34, 98, 23)
+        val channel1 = GpsSatelliteMessage( 8, Quantity(78, Degree), Quantity(253, Degree), null)
+        val channel2 = GpsSatelliteMessage(27, Quantity(60, Degree), Quantity( 55, Degree), 21)
+        val channel3 = GpsSatelliteMessage( 7, Quantity(56, Degree), Quantity(280, Degree), null)
+        val channel4 = GpsSatelliteMessage(16, Quantity(34, Degree), Quantity( 98, Degree), 23)
         val expectedGsv = GpsSatellitesInView(3, 1, 12, channel1, channel2, channel3, channel4)
 
         val gps = Gps({ '?' }, { })

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -2,12 +2,12 @@ package gps
 
 import gps.parser.Sentence
 import units.Degree
-import units.Knot
 import units.Metre
 import units.Quantity
 
 import org.junit.Assert
 import org.junit.Test
+import units.MetrePerSecond
 
 import java.time.OffsetDateTime
 import java.time.OffsetTime
@@ -19,7 +19,7 @@ class GpsTest {
         val gps = Gps({ '?' }, { })
         val vtg = gps.vtg(Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A")))
 
-        Assert.assertEquals(GpsGroundVelocity(Quantity(165.48, Degree), Quantity(0.03, Knot), 'A'), vtg)
+        Assert.assertEquals(GpsGroundVelocity(Quantity(165.48, Degree), Quantity(0.01543333332, MetrePerSecond), 'A'), vtg)
         Assert.assertTrue("Mode should be Autonomous", vtg.mode == GpsGroundVelocity.MODE_AUTONOMOUS)
     }
 
@@ -27,7 +27,7 @@ class GpsTest {
     fun testRmcSentence() {
         val time = OffsetDateTime.of(2006, 4, 26, 6, 49, 51, 0, ZoneOffset.UTC)
         val position = GpsPosition(latitude = Quantity(23.11876, Degree), longitude = Quantity(120.27406333333333, Degree))
-        val expectedGpsNavInfo = GpsNavInfo(time, true, position, Quantity(0.03, Knot), Quantity(165.48, Degree), 'A')
+        val expectedGpsNavInfo = GpsNavInfo(time, true, position, Quantity(0.01543333332, MetrePerSecond), Quantity(165.48, Degree), 'A')
 
         val gps = Gps({ '?' }, { })
         val rmc = gps.rmc(Sentence("GP", "RMC", arrayOf("064951.000", "A", "2307.1256", "N", "12016.4438", "E", "0.03", "165.48", "260406", "3.05", "W", "A")))

--- a/projects/units/README.md
+++ b/projects/units/README.md
@@ -1,0 +1,36 @@
+Units API
+=========
+
+- Requires [Kotlin 1.1][Kotlin]+
+- Based on [JSR 363]
+
+Principles
+----------
+
+1. Compile-time safety
+2. Explicitness
+
+Unit conversions
+----------------
+
+Unit conversions are exposed as [extensions] on the `Quantity` class and are defined inside the Unit they are for.
+
+For example, `Knot`s can be converted into in all other units of speed:
+
+```kotlin
+sealed class Speed(symbol: String): Unit<Speed>(symbol)
+object MetrePerSecond: Speed("m")
+object Knot: Speed("kn") {
+    inline fun <reified T: Speed> Quantity<Speed, Knot>.convert(to: Speed): Quantity<Speed, T> = when (to) {
+        Knot -> Quantity(value, to as T)
+        MetrePerSecond -> Quantity(value * 0.514444444, to as T)
+    }
+}
+```
+
+As new units for speed are added, all [when expression]s used to define conversions to `Speed`s will fail to compile and will need to updated to convert to the newly added unit.
+
+  [Kotlin]:https://kotlinlang.org
+  [JSR 363]:https://docs.google.com/document/d/12KhosAFriGCczBs6gwtJJDfg_QlANT92_lhxUWO2gCY
+  [extensions]:https://kotlinlang.org/docs/reference/extensions.html
+  [when expression]:https://kotlinlang.org/docs/reference/control-flow.html#when-expression

--- a/projects/units/build.gradle.kts
+++ b/projects/units/build.gradle.kts
@@ -1,0 +1,24 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestLogging
+
+repositories {
+    jcenter()
+}
+
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "1.1.2"
+}
+
+dependencies {
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
+    compile(project(":log"))
+    testCompile("junit:junit:4.12")
+    testCompile("org.jetbrains.kotlin:kotlin-test-junit")
+}
+
+tasks.withType<Test> {
+    testLogging(closureOf<TestLogging> {
+        showStandardStreams = true
+        events("passed", "skipped", "failed")
+    })
+}

--- a/projects/units/src/main/kotlin/units/Quantity.kt
+++ b/projects/units/src/main/kotlin/units/Quantity.kt
@@ -1,0 +1,11 @@
+package units
+
+data class Quantity<T : Unit<T>, U : Unit<T>>(val value: Double, private val unit: U) {
+    constructor(value: Int, unit: U): this(value.toDouble(), unit)
+
+    constructor(value: Long, unit: U): this(value.toDouble(), unit)
+
+    operator fun plus(o: Quantity<T, U>) = Quantity(value + o.value, unit)
+
+    override fun toString() = "$value$unit"
+}

--- a/projects/units/src/main/kotlin/units/Unit.kt
+++ b/projects/units/src/main/kotlin/units/Unit.kt
@@ -19,3 +19,6 @@ object Knot: Speed("kn") {
         MetrePerSecond -> Quantity(value * 0.514444444, to as T)
     }
 }
+
+sealed class SignalNoiseRatio(symbol: String): Unit<SignalNoiseRatio>(symbol)
+object Decibel: SignalNoiseRatio("dB")

--- a/projects/units/src/main/kotlin/units/Unit.kt
+++ b/projects/units/src/main/kotlin/units/Unit.kt
@@ -11,4 +11,10 @@ sealed class Length(symbol: String): Unit<Length>(symbol)
 object Metre: Length("m")
 
 sealed class Speed(symbol: String): Unit<Speed>(symbol)
-object Knot: Speed("kn")
+object MetrePerSecond: Speed("m")
+object Knot: Speed("kn") {
+    inline fun <reified T: Speed> Quantity<Speed, Knot>.convert(to: Speed): Quantity<Speed, T> = when (to) {
+        Knot -> Quantity(value, to as T)
+        MetrePerSecond -> Quantity(value * 0.514444444, to as T)
+    }
+}

--- a/projects/units/src/main/kotlin/units/Unit.kt
+++ b/projects/units/src/main/kotlin/units/Unit.kt
@@ -1,0 +1,14 @@
+package units
+
+sealed class Unit<U: Unit<U>>(val symbol: String) {
+    override fun toString() = symbol
+}
+
+sealed class Angle(symbol: String): Unit<Angle>(symbol)
+object Degree: Angle("°")
+
+sealed class Length(symbol: String): Unit<Length>(symbol)
+object Metre: Length("m")
+
+sealed class Speed(symbol: String): Unit<Speed>(symbol)
+object Knot: Speed("kn")

--- a/projects/units/src/main/kotlin/units/Unit.kt
+++ b/projects/units/src/main/kotlin/units/Unit.kt
@@ -1,5 +1,6 @@
 package units
 
+@kotlin.Suppress("unused")
 sealed class Unit<U: Unit<U>>(val symbol: String) {
     override fun toString() = symbol
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ include "gps"
 include "jmh"
 include "log"
 include "microcontrollers"
+include "units"
 
 rootProject.name = "boat"
 rootProject.buildFileName = "build.gradle.kts"


### PR DESCRIPTION
Closes #73 (this PR supersedes that one)
Closes #77 (this PR supersedes that one too)
Closes #53\*
Closes #54†

This PR updates the representations of the GPS data to include units. Previously we were storing "unitless" numbers and specifying the types implicitly (e.g. comments and documentation) and now we are moving to `Quantity`s  with `Unit`s. This API (similar to #73 and #77, the first two attempts) is heavily inspired by [the JSR 363 specification](https://docs.google.com/document/d/12KhosAFriGCczBs6gwtJJDfg_QlANT92_lhxUWO2gCY) but I've tried my darnedest to have an API that can be checked at compile time which unfortunately requires a slightly different API. I do think it would be possible to expose a `javax.measure` wrapper for the types introduced here so it's not completely pooh-poohing the standard.

The two main types in the API are `Unit` and `Quantity` (again, similar to JSR 363). `Unit` represents a hierarchy of units. `Quantity` represents a pairing of a value with an unit. All quantity values are [double-precision floating-point format numbers](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) (i.e. [`double`](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html)).

## Compile-time safety

Code using the API should fail to compile if it's wrong:

```kotlin
val oneInch = Quantity(1, Inch)
val oneMetre = Quantity(1, Metre)
val result = oneMetre + oneInch // This does not compile
```

An explicit version that compiles:

```kotlin
val oneInch = Quantity(1, Inch)
val oneMetre = Quantity(1, Metre)
val result = oneMetre + oneInch.convert(Metre) // Works
```

(I haven't actually implemented an `Inch`, the above is for demonstration purposes only.)

## What's the catch?

Using [extension functions][3] is kinda gross I guess.

---

\* I've migrated the position values from `dddmm.mmmm` and `ddmm.mmmm` to decimal degrees<sup>\[1\]</sup>.

† This PR actually does convert the speed to m/s 🚀 🎆 👏 🎉 (unlike #73 and #77).

1\. Which was already completed in 604710d725bc1275defb117895121dfba989f0d9 but I've taken the opportunity to move it into the GPS subproject properly. (As a side note to a side note: I was previously of the opinion that the GPS subproject should try to represent the GPS data in an [OO](https://en.wikipedia.org/wiki/Object-oriented_programming) way that doesn't *transform* the data. I no longer feel that way and think it's fine if the GPS project does sane conversions so long as we still have access to the underlying NMEA sentence that produced a value.)

  [2]:https://gis.stackexchange.com/a/8674
  [3]:https://kotlinlang.org/docs/reference/extensions.html