### PR TITLE
Set the JVM target version for Kotlin as 1.8 for all projects

### DIFF
--- a/projects/cli/build.gradle.kts
+++ b/projects/cli/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 repositories {
     jcenter()
 }
@@ -21,4 +23,10 @@ configure<ApplicationPluginConvention> {
     applicationName = rootProject.name
     version = rootProject.version
     mainClassName = "cli.Main"
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/projects/gps/build.gradle.kts
+++ b/projects/gps/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 repositories {
     jcenter()
@@ -21,4 +22,10 @@ tasks.withType<Test> {
         showStandardStreams = true
         events("passed", "skipped", "failed")
     })
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/projects/jmh/build.gradle.kts
+++ b/projects/jmh/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 repositories {
     jcenter()
 }
@@ -18,4 +20,10 @@ dependencies {
 
 configure<ApplicationPluginConvention> {
     mainClassName = "org.openjdk.jmh.Main"
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/projects/log/build.gradle.kts
+++ b/projects/log/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 repositories {
     jcenter()
 }
@@ -8,4 +10,10 @@ plugins {
 
 dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8")
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/projects/microcontrollers/build.gradle.kts
+++ b/projects/microcontrollers/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 repositories {
     jcenter()
@@ -21,4 +22,10 @@ tasks.withType<Test> {
         showStandardStreams = true
         events("passed", "skipped", "failed")
     })
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/projects/units/build.gradle.kts
+++ b/projects/units/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestLogging
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 repositories {
     jcenter()
@@ -21,4 +22,10 @@ tasks.withType<Test> {
         showStandardStreams = true
         events("passed", "skipped", "failed")
     })
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }


### PR DESCRIPTION
This PR fixes the issue with inlining across JVM targets.