### PR TITLE
Add surge and yaw PID controllers

### DIFF
--- a/projects/core/src/main/kotlin/core/Boat.kt
+++ b/projects/core/src/main/kotlin/core/Boat.kt
@@ -1,10 +1,24 @@
 package core
 
 import core.broadcast.Broadcast
+import core.control.ControlSystem
+import core.control.ControlSystemTransformer
+import core.control.Controller
+import core.control.PidController
+import core.geospatial.bearing
+import core.geospatial.distance
+import core.values.BoatConfig
+import core.values.ControlMode
 import core.values.GpsValue
 import core.values.Motion
+import core.values.Position
+import core.values.SurgeGains
+import core.values.Waypoint
+import core.values.YawGains
 import gps.GpsFix
 import gps.GpsNavInfo
+import units.Degree.convert
+import units.Radian
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -22,21 +36,58 @@ class Boat(private val broadcast: Broadcast, private val propulsionSystem: Propu
     private val killSwitch: Subject<Void, Void> = PublishSubject.create()
 
     fun start(io: Scheduler, clock: Scheduler) {
-        val speeds = broadcast.valuesOfType<Motion>()
-            .startWith(Motion(0.0, 0.0))
-            .map { speed(it) }
-            .onBackpressureLatest()
         val ticks = Observable.interval(SLEEP_DURATION_MS, TimeUnit.MILLISECONDS, clock)
-        val positions = Observable.combineLatest(
-            broadcast.valuesOfType<GpsFix>(),
-            broadcast.valuesOfType<GpsNavInfo>(),
-            { fix, nav -> Pair(fix, nav)}
-        )
+        val gpsNavInfo = broadcast.valuesOfType<GpsNavInfo>()
+        val gpsFix = broadcast.valuesOfType<GpsFix>()
+        val gps = Observable.combineLatest(gpsFix, gpsNavInfo, { fix, nav -> Pair(fix, nav) })
+            .flatMap { (fix, nav) -> GpsValue.from(nav, fix)?.let { Observable.just(it) } ?: Observable.empty() }
+        val positions = gps.map { it.position }
+        val config = broadcast.valuesOfType<BoatConfig>()
+            .startWith(BoatConfig(SurgeGains(1.0, 1.0, 1.0), 1.0, YawGains(1.0, 1.0, 1.0), 1.0))
+        val surge = broadcast.valuesOfType<Waypoint>()
+            .withLatestFrom(config, { w: Waypoint, c: BoatConfig -> Pair(w, c) })
+            .switchMap({ (waypoint, config) ->
+                val initialController = PidController(config.surgeGains.gains, { Motion.clamp(it) })
+                val controlSystems = broadcast.valuesOfType<SurgeGains>()
+                    .scan(initialController, { cs, g -> cs.setGains(g.gains) })
+                    .map { ControlSystem(it, { a: Position, b: Position -> distance(a, b).value }) }
 
-        positions.observeOn(io)
-            .subscribe { (fix, nav) ->
-                GpsValue.from(nav, fix).let { broadcast.send(it).toBlocking().subscribe() }
-            }
+                positions
+                    .onBackpressureDrop()
+                    .compose(ControlSystemTransformer(waypoint.position, controlSystems, clock))
+            })
+        val yaw = broadcast.valuesOfType<Waypoint>()
+            .withLatestFrom(config, { w: Waypoint, c: BoatConfig -> Pair(w, c) })
+            .switchMap({ (waypoint, config) ->
+                val initialController = PidController(config.yawGains.gains, { Motion.clamp(it) })
+                val controllers = broadcast.valuesOfType<YawGains>()
+                    .scan(initialController, { cs, g -> cs.setGains(g.gains) })
+                val controlSystems = gps
+                    .withLatestFrom(controllers, { gps: GpsValue, controller: Controller -> Pair(controller, gps) })
+                    .map { (c, g) ->
+                        ControlSystem(c, fun (a: Position, b: Position): Double {
+                            val actualBearing = g.velocity.trueBearing.convert<Radian>(Radian)
+                            val desiredBearing = bearing(a, b).convert<Radian>(Radian)
+                            val error = (actualBearing - desiredBearing).value
+                            return Math.atan2(Math.sin(error), Math.cos(error))
+                        })
+                    }
+
+                positions
+                    .onBackpressureDrop()
+                    .compose(ControlSystemTransformer(waypoint.position, controlSystems, clock))
+            })
+        val speeds = broadcast.valuesOfType<ControlMode>()
+            .startWith(ControlMode.MANUAL)
+            .switchMap({
+                when (it) {
+                    ControlMode.MANUAL   -> broadcast.valuesOfType<Motion>()
+                    ControlMode.WAYPOINT -> Observable.combineLatest(surge, yaw, ::Motion).startWith(Motion(0.0, 0.0))
+                }
+            })
+            .map(this::speed)
+
+        gps.observeOn(io).subscribe { broadcast.send(it).toBlocking().subscribe() }
 
         ticks.withLatestFrom(speeds, { _, s -> s })
             .observeOn(io)

--- a/projects/core/src/main/kotlin/core/values/BoatConfig.kt
+++ b/projects/core/src/main/kotlin/core/values/BoatConfig.kt
@@ -1,0 +1,15 @@
+package core.values
+
+import schemas.TypedMessageProtobuf
+
+data class BoatConfig(val surgeGains: SurgeGains, val surgeDt: Double, val yawGains: YawGains, val yawDt: Double) {
+    companion object {
+        fun decode(bytes: ByteArray): BoatConfig {
+            val obj = TypedMessageProtobuf.TypedMessage.parseFrom(bytes)
+            val boatConfig = obj.boatConfig
+            val surgeGains = SurgeGains(boatConfig.surgeControllerGains.kp, boatConfig.surgeControllerGains.ki, boatConfig.surgeControllerGains.kd)
+            val yawGains = YawGains(boatConfig.yawControllerGains.kp, boatConfig.yawControllerGains.ki, boatConfig.yawControllerGains.kd)
+            return BoatConfig(surgeGains, boatConfig.surgeControllerDt, yawGains, boatConfig.yawControllerDt)
+        }
+    }
+}

--- a/projects/core/src/main/kotlin/core/values/SurgeGains.kt
+++ b/projects/core/src/main/kotlin/core/values/SurgeGains.kt
@@ -1,0 +1,7 @@
+package core.values
+
+import core.control.PidController.Gains
+
+data class SurgeGains(private val kp: Double, private val ki: Double, private val kd: Double) {
+    val gains = Gains(kp, ki, kd)
+}

--- a/projects/core/src/main/kotlin/core/values/YawGains.kt
+++ b/projects/core/src/main/kotlin/core/values/YawGains.kt
@@ -1,0 +1,7 @@
+package core.values
+
+import core.control.PidController.Gains
+
+data class YawGains(private val kp: Double, private val ki: Double, private val kd: Double) {
+    val gains = Gains(kp, ki, kd)
+}


### PR DESCRIPTION
Refs #75 (which contains most of the discussion around the control system)
Refs #82 (which contains discussion about the controller implementation and the error functions)

This PR adds the surge and yaw controllers using the `PidController` introduced in #82.