### PR TITLE
Rename TypedMessageSerializer to ValueSerializer

### DIFF
--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -6,7 +6,7 @@ import core.Boat
 import core.PropulsionSystem
 import core.broadcast.*
 import core.values.GpsValue
-import core.values.TypedMessageSerializer
+import core.values.ValueSerializer
 import gps.Gps
 import log.Log
 import microcontrollers.PropulsionMicrocontroller
@@ -40,7 +40,7 @@ fun main(args: Array<String>) {
     val broadcast = InMemoryBroadcast()
     val port = 12345
     val udpBroadcast = UdpBroadcast(
-        DatagramSocket(port), InetAddress.getByName(args[0]), port, TypedMessageSerializer(), BasicOrder())
+        DatagramSocket(port), InetAddress.getByName(args[0]), port, ValueSerializer(), BasicOrder())
     val pSerialPort = SerialPort(args[1], baudRate = 57600)
     val gSerialPort = SerialPort(args[2], baudRate =  9600)
     val propulsionMicrocontroller = PropulsionMicrocontroller(ReentrantLock(), pSerialPort::recv, pSerialPort::send)

--- a/projects/core/src/main/kotlin/core/values/ValueSerializer.kt
+++ b/projects/core/src/main/kotlin/core/values/ValueSerializer.kt
@@ -4,7 +4,7 @@ import schemas.TypedMessageProtobuf.TypedMessage.Type
 
 import rx.broadcast.Serializer
 
-class TypedMessageSerializer: Serializer<Any> {
+class ValueSerializer : Serializer<Any> {
     override fun decode(data: ByteArray): Any = when (typedMessage(data).type!!) {
         Type.BOAT_CONFIG -> BoatConfig.decode(data)
         Type.CONTROL_MODE -> ControlMode.decode(data)


### PR DESCRIPTION
I think this name makes more sense as I see `TypedMessage` as an implementation detail.