### PR TITLE
Add NMEA sentence parser support for PMTK sentences

### DIFF
--- a/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
@@ -40,9 +40,12 @@ internal sealed class SentenceState {
             // valid with the correct fields and whatnot. If that turns out to not be the
             // case, we might regret this decision.
             val type = charArrayOf(recv(), recv(), recv())
-            // This next char should be field delimiter and we'll throw it away
-            recv()
-            return SentenceState.Fields(talker, type)
+            return when (recv()) {
+                Sentence.FIELD_DELIMITER -> SentenceState.Fields(talker, type)
+                Sentence.CHECKSUM_DELIMITER -> SentenceState.Checksum(talker, type, arrayOf())
+                // We seem to have recv'd something incorrect
+                else -> SentenceState.Prefix()
+            }
         }
     }
 

--- a/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/SentenceState.kt
@@ -1,5 +1,7 @@
 package gps.parser
 
+import java.util.Arrays
+
 internal sealed class SentenceState {
     companion object {
         const val MAXIMUM_SENTENCE_LENGTH = 82
@@ -17,8 +19,14 @@ internal sealed class SentenceState {
     }
 
     internal class Talker: SentenceState() {
+        private val PM_TALKER_ID = charArrayOf('P', 'M')
+
         fun next(recv: () -> Char): SentenceState {
-            val talker = charArrayOf(recv(), recv())
+            var talker = charArrayOf(recv(), recv())
+            if (Arrays.equals(talker, PM_TALKER_ID)) {
+                // The PM Talker ID is four bytes
+                talker += charArrayOf(recv(), recv())
+            }
             return SentenceState.MessageType(talker)
         }
     }

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
@@ -684,3 +684,27 @@ class SentenceParserEdgeCasesTest(msg: String, private val expected: String, pri
         Assert.assertEquals(expected, sentence.toString())
     }
 }
+
+@RunWith(Parameterized::class)
+class SentenceParserCommandPacketTest(private val message: String) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() : Collection<Array<String>> {
+            return listOf(
+                // From the PMTK command packet
+                arrayOf("\$PMTK220,100*2F"),
+                arrayOf("\$PMTK251,57600*2C")
+            )
+        }
+    }
+
+    @Test(timeout = 10000)
+    fun parseMessage() {
+        val chars = message.toCharArray()
+        var count = 0
+        val parser = SentenceParser({ chars[count++] })
+        val sentence = parser.nextMessage()
+        Assert.assertEquals(sentence.toString(), message)
+    }
+}

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
@@ -695,6 +695,7 @@ class SentenceParserCommandPacketTest(private val message: String) {
                 // From the PMTK command packet
                 arrayOf("\$PMTK010,001*2E"),
                 arrayOf("\$PMTK011,MTKGPS*08"),
+                arrayOf("\$PMTK001,604,3*32"),
                 arrayOf("\$PMTK220,100*2F"),
                 arrayOf("\$PMTK251,57600*2C")
             )

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
@@ -697,6 +697,10 @@ class SentenceParserCommandPacketTest(private val message: String) {
                 arrayOf("\$PMTK011,MTKGPS*08"),
                 arrayOf("\$PMTK001,604,3*32"),
                 arrayOf("\$PMTK220,100*2F"),
+                arrayOf("\$PMTK101*32"),
+                arrayOf("\$PMTK102*31"),
+                arrayOf("\$PMTK103*30"),
+                arrayOf("\$PMTK104*37"),
                 arrayOf("\$PMTK251,57600*2C")
             )
         }

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceParserTest.kt
@@ -693,6 +693,8 @@ class SentenceParserCommandPacketTest(private val message: String) {
         fun data() : Collection<Array<String>> {
             return listOf(
                 // From the PMTK command packet
+                arrayOf("\$PMTK010,001*2E"),
+                arrayOf("\$PMTK011,MTKGPS*08"),
                 arrayOf("\$PMTK220,100*2F"),
                 arrayOf("\$PMTK251,57600*2C")
             )


### PR DESCRIPTION
This PR adds support for PMTK sentences in the GPS `SentenceParser`.

I would like to take this moment to thank GlobalTop (or whoever) for having a four character talker ID (`PMTK`) instead of a two character talker ID. It's not as if everyone thinks talker IDs are supposed to be two chara—oh, wait:

> NMEA sentences do, however, include a "talker ID" a **two-character** prefix that identifies the type of the transmitting unit.
> *— [NMEA Revealed](http://www.catb.org/gpsd/NMEA.html#_talker_ids)*

> The first **two letters** following the „$” are the talker identifier.
> *— [Standard NMEA-0183 sentences description](http://freenmea.net/docs)*

> A popular GPS communication protocol is the one specified by NMEA (see [here](http://caxapa.ru/thumbs/214299/NMEA0183_.pdf)). Communication is done in "sentences", which start with `$--` where `--` is the *talker ID*.
> *— [What is the talker ID of this GPS receiver?](https://electronics.stackexchange.com/q/30812)*

> NMEA 0183 protocol uses **two-character** “talker IDs” at the beginning of each sentence, which identify the source of the sentence.
> *— [NMEA IDs](https://github.com/mvglasow/satstat/wiki/NMEA-IDs)*

ugh.

I know that proprietary sentences are a thing, but using a two character talker ID still would've been nice. ugh.