### PR TITLE
Implement hardware serial GPS

### DIFF
--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -44,7 +44,7 @@ fun main(args: Array<String>) {
     val pSerialPort = SerialPort(args[1], baudRate = 57600)
     val gSerialPort = SerialPort(args[2], baudRate =  9600)
     val propulsionMicrocontroller = PropulsionMicrocontroller(ReentrantLock(), pSerialPort::recv, pSerialPort::send)
-    val gpsMicrocontroller = Gps({ gSerialPort.recv().toChar() }, { msg -> broadcast.send(msg).subscribe() })
+    val gpsReceiver = Gps({ gSerialPort.recv().toChar() }, { msg -> broadcast.send(msg).subscribe() })
 
     val boat = Boat(broadcast, PropulsionSystem(propulsionMicrocontroller))
 
@@ -55,7 +55,7 @@ fun main(args: Array<String>) {
         .observeOn(Schedulers.io())
         .subscribe {
             try {
-                gpsMicrocontroller.poll()
+                gpsReceiver.poll()
             } catch (e: Exception) {
                 Log.w { "$e" }
                 /* TODO: issue #67 */

--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -50,9 +50,11 @@ fun main(args: Array<String>) {
     val boat = Boat(broadcast, PropulsionSystem(propulsionMicrocontroller))
 
     gpsReceiver.setNmeaBaudRate(PMTK.BaudRate.BAUD_RATE_57600)
+    gpsReceiver.poll()
     gSerialPort.disconnect()
     gSerialPort = gSerialPort.copy(baudRate = 57600)
     gpsReceiver.setNmeaUpdateRate(PMTK.UpdateRate(100))
+    gpsReceiver.poll()
 
     Runtime.getRuntime().addShutdownHook(Thread(boat::shutdown))
     boat.start(io = Schedulers.io(), clock = Schedulers.computation())

--- a/projects/cli/src/main/kotlin/cli/SerialPort.kt
+++ b/projects/cli/src/main/kotlin/cli/SerialPort.kt
@@ -1,6 +1,6 @@
 package cli
 
-internal class SerialPort(name: String, val baudRate: Int) {
+internal data class SerialPort(val name: String, val baudRate: Int) {
     private val serialPort = com.fazecast.jSerialComm.SerialPort.getCommPort(name)!!
 
     private val readBuffer = ByteArray(1)

--- a/projects/cli/src/main/kotlin/cli/SerialPort.kt
+++ b/projects/cli/src/main/kotlin/cli/SerialPort.kt
@@ -19,4 +19,8 @@ internal class SerialPort(name: String, val baudRate: Int) {
     fun send(bytes: ByteArray) {
         serialPort.writeBytes(bytes, bytes.size.toLong())
     }
+
+    fun disconnect() {
+        serialPort.closePort()
+    }
 }

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -33,8 +33,20 @@ import java.time.format.DateTimeFormatter
  * @param recv an input function returning a character from the GPS
  * @param callback an output function accepting a GPS sentence
  */
-class Gps(recv: () -> Char, private val callback: (Any) -> Unit) {
+class Gps(recv: () -> Char, private val send: (ByteArray) -> Unit, private val callback: (Any) -> Unit) {
     private val parser = SentenceParser(recv)
+
+    fun setNmeaBaudRate(baudRate: PMTK.BaudRate) {
+        val sentence = Sentence("PMTK", "251", arrayOf(baudRate.baudRate.toString()))
+        send(sentence.toString().toByteArray(Charsets.US_ASCII))
+        poll()
+    }
+
+    fun setNmeaUpdateRate(updateRate: PMTK.UpdateRate) {
+        val sentence = Sentence("PMTK", "220", arrayOf(updateRate.milliseconds.toString()))
+        send(sentence.toString().toByteArray(Charsets.US_ASCII))
+        poll()
+    }
 
     fun poll() {
         val sentence = parser.nextMessage()

--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -39,13 +39,11 @@ class Gps(recv: () -> Char, private val send: (ByteArray) -> Unit, private val c
     fun setNmeaBaudRate(baudRate: PMTK.BaudRate) {
         val sentence = Sentence("PMTK", "251", arrayOf(baudRate.baudRate.toString()))
         send(sentence.toString().toByteArray(Charsets.US_ASCII))
-        poll()
     }
 
     fun setNmeaUpdateRate(updateRate: PMTK.UpdateRate) {
         val sentence = Sentence("PMTK", "220", arrayOf(updateRate.milliseconds.toString()))
         send(sentence.toString().toByteArray(Charsets.US_ASCII))
-        poll()
     }
 
     fun poll() {

--- a/projects/gps/src/main/kotlin/gps/PMTK.kt
+++ b/projects/gps/src/main/kotlin/gps/PMTK.kt
@@ -2,7 +2,7 @@ package gps
 
 class PMTK {
     sealed class BaudRate(val baudRate: Int) {
-        object BAUD_RATE_57600 : BaudRate(7600)
+        object BAUD_RATE_57600 : BaudRate(57600)
     }
 
     class UpdateRate(val milliseconds: Int) {

--- a/projects/gps/src/main/kotlin/gps/PMTK.kt
+++ b/projects/gps/src/main/kotlin/gps/PMTK.kt
@@ -1,0 +1,15 @@
+package gps
+
+class PMTK {
+    sealed class BaudRate(val baudRate: Int) {
+        object BAUD_RATE_57600 : BaudRate(7600)
+    }
+
+    class UpdateRate(val milliseconds: Int) {
+        init {
+            require(milliseconds in 100..10000, {
+                "The possible position fix interval values range between 100 and 10000 milliseconds."
+            })
+        }
+    }
+}

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -168,4 +168,20 @@ class GpsTest {
 
         Assert.assertEquals(expectedGsv, gsv)
     }
+
+    @Test
+    fun testSetNmeaBaudRate() {
+        var bytes = byteArrayOf()
+        val gps = Gps(recv = { '?' }, send =  { bytes = it }, callback = { })
+        gps.setNmeaBaudRate(PMTK.BaudRate.BAUD_RATE_57600)
+        Assert.assertEquals("\$PMTK251,57600*2C", bytes.toString(Charsets.US_ASCII))
+    }
+
+    @Test
+    fun testSetNmeaUpdateRate() {
+        var bytes = byteArrayOf()
+        val gps = Gps(recv = { '?' }, send =  { bytes = it }, callback = { })
+        gps.setNmeaUpdateRate(PMTK.UpdateRate(100))
+        Assert.assertEquals("\$PMTK220,100*2F", bytes.toString(Charsets.US_ASCII))
+    }
 }

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -17,7 +17,7 @@ import java.time.ZoneOffset
 class GpsTest {
     @Test
     fun testVtgSentence() {
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val vtg = gps.vtg(Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A")))
 
         Assert.assertEquals(GpsGroundVelocity(Quantity(165.48, Degree), Quantity(0.01543333332, MetrePerSecond), 'A'), vtg)
@@ -30,7 +30,7 @@ class GpsTest {
         val position = GpsPosition(latitude = Quantity(23.11876, Degree), longitude = Quantity(120.27406333333333, Degree))
         val expectedGpsNavInfo = GpsNavInfo(time, true, position, Quantity(0.01543333332, MetrePerSecond), Quantity(165.48, Degree), 'A')
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val rmc = gps.rmc(Sentence("GP", "RMC", arrayOf("064951.000", "A", "2307.1256", "N", "12016.4438", "E", "0.03", "165.48", "260406", "3.05", "W", "A")))
 
         Assert.assertEquals(expectedGpsNavInfo, rmc)
@@ -46,7 +46,7 @@ class GpsTest {
         val channel4 = GpsSatelliteMessage(15, Quantity(21, Degree), Quantity(321, Degree), Quantity(39, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 1, 9, channel1, channel2, channel3, channel4)
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "1", "09", "29", "36", "029", "42", "21", "46", "314", "43", "26", "44", "020", "43", "15", "21", "321", "39")))
 
         Assert.assertEquals(expectedGsv, gsv)
@@ -60,7 +60,7 @@ class GpsTest {
         val channel4 = GpsSatelliteMessage(10, Quantity(26, Degree), Quantity( 84, Degree), Quantity(37, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 2, 9, channel1, channel2, channel3, channel4)
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "2", "09", "18", "26", "314", "40", "09", "57", "170", "44", "06", "20", "229", "37", "10", "26", "084", "37")))
 
         Assert.assertEquals(expectedGsv, gsv)
@@ -71,7 +71,7 @@ class GpsTest {
         val channel1 = GpsSatelliteMessage(7, null,  null, Quantity(26, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 3, 9, channel1)
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "3", "09", "07", "", "", "26")))
 
         Assert.assertEquals(expectedGsv, gsv)
@@ -81,7 +81,7 @@ class GpsTest {
     fun testGsaSentence() {
         val expectedGsa = GpsActiveSatellites('A', '3', GpsChannelArray(intArrayOf(29, 21, 26, 15, 18, 9, 6, 10)), GpsDilutionOfPrecision(2.32, 0.95, 2.11))
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsa = gps.gsa(Sentence("GP", "GSA", arrayOf("A", "3", "29", "21", "26", "15", "18", "09", "06", "10", "", "", "", "", "2.32", "0.95", "2.11")))
 
         Assert.assertEquals(expectedGsa, gsa)
@@ -95,7 +95,7 @@ class GpsTest {
         val position = GpsPosition(latitude = Quantity(23.11876, Degree), longitude = Quantity(120.27406333333333, Degree))
         val expected = GpsFix(time, position, '1', 8, GpsDilutionOfPrecision(horizontal = 0.95), Quantity(39.9, Metre), Quantity(17.8, Metre))
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "2307.1256", "N", "12016.4438", "E", "1", "8", "0.95", "39.9", "M", "17.8", "M", "", "")))
 
         Assert.assertEquals(expected, gsa)
@@ -105,7 +105,7 @@ class GpsTest {
     fun testEmptyGgaSentence() {
         val expected = GpsFix(OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC), null, '0', 1, null, null, null)
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "", "", "", "", "0", "01", "", "", "", "", "", "", "")))
 
         Assert.assertEquals(expected, gsa)
@@ -116,7 +116,7 @@ class GpsTest {
         val time = OffsetDateTime.of(2006, 4, 26, 6, 49, 51, 0, ZoneOffset.UTC)
         val expectedGpsNavInfo = GpsNavInfo(time, false, null, null, null, 'N')
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val rmc = gps.rmc(Sentence("GP", "RMC", arrayOf("064951.000", "V", "", "", "", "", "", "", "260406", "", "", "N")))
 
         Assert.assertEquals(expectedGpsNavInfo, rmc)
@@ -127,7 +127,7 @@ class GpsTest {
     fun testGsvSentenceWithoutLock() {
         val expectedGsv = GpsSatellitesInView(1, 1, 0, null)
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("1", "1", "00")))
 
         Assert.assertEquals(expectedGsv, gsv)
@@ -137,7 +137,7 @@ class GpsTest {
     fun testGsaSentenceWithoutLock() {
         val expectedGsa = GpsActiveSatellites('A', '1', GpsChannelArray(intArrayOf()), GpsDilutionOfPrecision())
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsa = gps.gsa(Sentence("GP", "GSA", arrayOf("A", "1", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "")))
 
         Assert.assertEquals(expectedGsa, gsa)
@@ -149,7 +149,7 @@ class GpsTest {
     fun testGgaSentenceWithoutLock() {
         val expected = GpsFix(OffsetTime.of(6, 49, 51, 0, ZoneOffset.UTC), null, '0', 0, null, null, Quantity(0, Metre))
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsa = gps.gga(Sentence("GP", "GGA", arrayOf("064951.000", "", "", "", "", "0", "00", "", "", "M", "0.0", "M", "", "0000")))
 
         Assert.assertEquals(expected, gsa)
@@ -163,7 +163,7 @@ class GpsTest {
         val channel4 = GpsSatelliteMessage(16, Quantity(34, Degree), Quantity( 98, Degree), Quantity(23, Decibel))
         val expectedGsv = GpsSatellitesInView(3, 1, 12, channel1, channel2, channel3, channel4)
 
-        val gps = Gps({ '?' }, { })
+        val gps = Gps({ '?' }, { }, { })
         val gsv = gps.gsv(Sentence("GP", "GSV", arrayOf("3", "1", "12", "08", "78", "253", "", "27", "60", "055", "21", "07", "56", "280", "", "16", "34", "098", "23")))
 
         Assert.assertEquals(expectedGsv, gsv)


### PR DESCRIPTION
Closes #40
Closes #90

This PR updates the control software for the new GPS receiver. All the sentence parsing is the same.

At start-up we now:

1. Connect to the receiver using 9600 baud
1. Set the NMEA baud rate to 57600 (`PMTK_SET_NMEA_BAUDRATE`)
1. Disconnect and reconnect using 57600 baud
1. Set the NMEA update rate to 10 Hz (`PMTK_SET_NMEA_UPDATERATE`)