### PR TITLE
Cleanup GPS polling Observable in Main

### DIFF
--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -61,14 +61,8 @@ fun main(args: Array<String>) {
 
     Observable.interval(500, TimeUnit.MILLISECONDS)
         .observeOn(Schedulers.io())
-        .subscribe {
-            try {
-                gpsReceiver.poll()
-            } catch (e: Exception) {
-                Log.w { "$e" }
-                /* TODO: issue #67 */
-            }
-        }
+        .flatMap({ Observable.fromCallable(gpsReceiver::poll) })
+        .subscribe()
 
     broadcast.valuesOfType<GpsValue>()
         .observeOn(Schedulers.io())

--- a/projects/cli/src/main/kotlin/cli/Main.kt
+++ b/projects/cli/src/main/kotlin/cli/Main.kt
@@ -62,6 +62,8 @@ fun main(args: Array<String>) {
     Observable.interval(500, TimeUnit.MILLISECONDS)
         .observeOn(Schedulers.io())
         .flatMap({ Observable.fromCallable(gpsReceiver::poll) })
+        // TODO: issue #67
+        .retry { _, error -> Log.w { "$error" }; true }
         .subscribe()
 
     broadcast.valuesOfType<GpsValue>()


### PR DESCRIPTION
This PR cleans up the way the GPS polling stream is created in `Main`, moving the polling out of the call to subscribe and into the stream proper. This change brings to light the fact that the `Gps#poll` should probably return its value instead of using a callback, but I'll save that change for later.