### PR TITLE
Add Oracle JDK 9 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
         - TERM=dumb
 jdk:
     - oraclejdk8
+    - oraclejdk9
     - openjdk8
 before_install:
     - (

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ jdk:
     - oraclejdk8
     - oraclejdk9
     - openjdk8
+matrix:
+    allow_failures:
+        - jdk: oraclejdk9
 before_install:
     - (
            cd "${HOME}"


### PR DESCRIPTION
Closes #120

This PR adds Oracle's JDK 9 to the build matrix.