### PR TITLE
Add CRLF to outbound PMTK sentences

### DIFF
--- a/projects/gps/src/main/kotlin/gps/Gps.kt
+++ b/projects/gps/src/main/kotlin/gps/Gps.kt
@@ -38,12 +38,12 @@ class Gps(recv: () -> Char, private val send: (ByteArray) -> Unit, private val c
 
     fun setNmeaBaudRate(baudRate: PMTK.BaudRate) {
         val sentence = Sentence("PMTK", "251", arrayOf(baudRate.baudRate.toString()))
-        send(sentence.toString().toByteArray(Charsets.US_ASCII))
+        send((sentence.toString() + "\r\n").toByteArray(Charsets.US_ASCII))
     }
 
     fun setNmeaUpdateRate(updateRate: PMTK.UpdateRate) {
         val sentence = Sentence("PMTK", "220", arrayOf(updateRate.milliseconds.toString()))
-        send(sentence.toString().toByteArray(Charsets.US_ASCII))
+        send((sentence.toString() + "\r\n").toByteArray(Charsets.US_ASCII))
     }
 
     fun poll() {

--- a/projects/gps/src/test/kotlin/gps/GpsTest.kt
+++ b/projects/gps/src/test/kotlin/gps/GpsTest.kt
@@ -174,7 +174,7 @@ class GpsTest {
         var bytes = byteArrayOf()
         val gps = Gps(recv = { '?' }, send =  { bytes = it }, callback = { })
         gps.setNmeaBaudRate(PMTK.BaudRate.BAUD_RATE_57600)
-        Assert.assertEquals("\$PMTK251,57600*2C", bytes.toString(Charsets.US_ASCII))
+        Assert.assertEquals("\$PMTK251,57600*2C\r\n", bytes.toString(Charsets.US_ASCII))
     }
 
     @Test
@@ -182,6 +182,6 @@ class GpsTest {
         var bytes = byteArrayOf()
         val gps = Gps(recv = { '?' }, send =  { bytes = it }, callback = { })
         gps.setNmeaUpdateRate(PMTK.UpdateRate(100))
-        Assert.assertEquals("\$PMTK220,100*2F", bytes.toString(Charsets.US_ASCII))
+        Assert.assertEquals("\$PMTK220,100*2F\r\n", bytes.toString(Charsets.US_ASCII))
     }
 }


### PR DESCRIPTION
This PR adds a carriage return and newline (CR+LF, `0x0d0a`) to the PMTK sentences that are sent to the GPS.