### PR TITLE
Flush output before disconnecting from SerialPort

### DIFF
--- a/projects/cli/src/main/kotlin/cli/SerialPort.kt
+++ b/projects/cli/src/main/kotlin/cli/SerialPort.kt
@@ -23,6 +23,7 @@ internal data class SerialPort(val name: String, val baudRate: Int) {
     }
 
     fun disconnect() {
+        serialPort.outputStream.flush();
         serialPort.closePort()
     }
 }


### PR DESCRIPTION
This PR updates the `SerialPort` connection to flush the output stream before disconnecting.