### PR TITLE
Read and validate serial sent byte counts

### DIFF
--- a/projects/bin/src/main/kotlin/bin/SerialPort.kt
+++ b/projects/bin/src/main/kotlin/bin/SerialPort.kt
@@ -19,7 +19,13 @@ internal data class SerialPort(val name: String, val baudRate: Int) {
     fun recvChar(): Char = recvByte().toChar()
 
     fun send(bytes: ByteArray) {
-        serialPort.writeBytes(bytes, bytes.size.toLong())
+        val sentCount = serialPort.writeBytes(bytes, bytes.size.toLong())
+        if (sentCount == -1) {
+            throw RuntimeException("Could not write to the serial device")
+        }
+        if (sentCount != bytes.size) {
+            throw RuntimeException("Error writing ${bytes.size} bytes to the device, $sentCount sent")
+        }
     }
 
     fun disconnect() {


### PR DESCRIPTION
Fixes #141

This PR updates the `SerialPort` wrapper to assert that the correct number of bytes have been written to the serial device.