### PR TITLE
Remove unneeded semicolon

### DIFF
--- a/projects/bin/src/main/kotlin/bin/SerialPort.kt
+++ b/projects/bin/src/main/kotlin/bin/SerialPort.kt
@@ -23,7 +23,7 @@ internal data class SerialPort(val name: String, val baudRate: Int) {
     }
 
     fun disconnect() {
-        serialPort.outputStream.flush();
+        serialPort.outputStream.flush()
         serialPort.closePort()
     }
 }


### PR DESCRIPTION
This PR contains a small style fix for the `SerialPort` class.