### PR TITLE
Validate GPS sentence checksums in SentenceParser

### DIFF
--- a/projects/gps/src/main/kotlin/gps/parser/Sentence.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/Sentence.kt
@@ -30,16 +30,16 @@ class Sentence(val talker: CharArray, val type: CharArray, val fields: Array<Cha
         fields.fold(charArrayOf(), { acc, chars -> acc + FIELD_DELIMITER + chars })
     }
 
-    val checksum: Char by lazy {
+    val checksum: Int by lazy {
         checksum(talker + type + data)
     }
 
-    private fun checksum(chars: CharArray): Char {
-        return chars.fold(0, { acc, c -> acc.xor(c.toInt()) }).toChar()
+    private fun checksum(chars: CharArray): Int {
+        return chars.fold(0, { acc, c -> acc.xor(c.toInt()) })
     }
 
     override fun toString(): String {
-        val cs = String.format(Locale.ENGLISH, "%s%02X", CHECKSUM_DELIMITER, checksum.toByte())
+        val cs = String.format(Locale.ENGLISH, "%s%02X", CHECKSUM_DELIMITER, checksum)
         return (talker + type + data).joinToString(prefix = MESSAGE_START.toString(), separator = "", postfix = cs)
     }
 }

--- a/projects/gps/src/main/kotlin/gps/parser/SentenceParser.kt
+++ b/projects/gps/src/main/kotlin/gps/parser/SentenceParser.kt
@@ -10,9 +10,7 @@ class SentenceParser(private val recv: () -> Char) {
                 is SentenceState.MessageType -> state.next(recv)
                 is SentenceState.Fields      -> state.next(recv)
                 is SentenceState.Checksum    -> state.next(recv)
-                is SentenceState.Complete    -> {
-                    return Sentence(state.talker, state.type, state.fields)
-                }
+                is SentenceState.Complete    -> return state.sentence
             }
         }
     }

--- a/projects/gps/src/test/kotlin/gps/parser/SentenceTest.kt
+++ b/projects/gps/src/test/kotlin/gps/parser/SentenceTest.kt
@@ -7,7 +7,7 @@ class SentenceTest {
     @Test
     fun sentenceChecksumIsCorrect() {
         val s = Sentence("GP", "VTG", arrayOf("165.48", "T", "", "M", "0.03", "N", "0.06", "K", "A"))
-        Assert.assertTrue(s.checksum == 54.toChar())
+        Assert.assertTrue(s.checksum == 54)
     }
 
     @Test


### PR DESCRIPTION
Refs #67

This PR validates the checksum of the NMEA sentences read from the GPS. This, [as discussed in #67](https://github.com/LakeMaps/boat/issues/67#issuecomment-372049320), is somewhat misleading as it does **not** reflect correct or valid sentences. It solely confirms that these are the bytes that the GPS sent us. Each sentence must be consumed with caution and subjected to further validation and error handling.